### PR TITLE
Accept 'timestamp' name for time data

### DIFF
--- a/kotori/daq/storage/influx.py
+++ b/kotori/daq/storage/influx.py
@@ -155,7 +155,7 @@ class InfluxDBAdapter(object):
 
         # Extract timestamp field from data
         chunk['time_precision'] = 'n'
-        for time_field in ['time', 'datetime', 'dateTime']:
+        for time_field in ['time', 'datetime', 'dateTime', 'timestamp']:
             if time_field in data:
 
                 # WeeWX. TODO: Move to specific vendor configuration.


### PR DESCRIPTION
There may be a reason why we don't use this field name but I stumbled across this not working as expected last evening. 