### PR TITLE
Acquire bulk readings in compact JSON format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 in progress
 ===========
 - **InfluxDB:** Added capability to acquire bulk readings in JSON format
+- **MQTT:** Added capability to acquire bulk readings in compact JSON format,
+  with timestamps as keys
 
 .. _kotori-0.28.0:
 

--- a/kotori/daq/decoder/__init__.py
+++ b/kotori/daq/decoder/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # (c) 2019-2021 Andreas Motl <andreas@getkotori.org>
 from kotori.daq.decoder.airrohr import AirrohrDecoder
+from kotori.daq.decoder.json import CompactTimestampedJsonDecoder
 from kotori.daq.decoder.tasmota import TasmotaSensorDecoder, TasmotaStateDecoder
 from kotori.daq.decoder.schema import MessageType
 from kotori.daq.decoder.tts_ttn import TheThingsStackDecoder
@@ -23,6 +24,12 @@ class DecoderManager:
 
         if 'slot' not in self.topology:
             return False
+
+        # Compact JSON format, with timestamps as keys
+        if self.topology.slot.endswith('tc.json'):
+            self.info.message_type = MessageType.DATA_CONTAINER
+            self.info.decoder = CompactTimestampedJsonDecoder
+            return True
 
         # Airrohr
         if self.topology.slot.endswith('airrohr.json'):

--- a/kotori/daq/decoder/json.py
+++ b/kotori/daq/decoder/json.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# (c) 2021 Andreas Motl <andreas@getkotori.org>
+import json
+
+
+class CompactTimestampedJsonDecoder:
+    """
+    Decode JSON payloads in compact format, with timestamps as keys.
+
+    Documentation
+    =============
+    - https://getkotori.org/docs/handbook/decoders/json.html (not yet)
+    - https://github.com/daq-tools/kotori/issues/39
+
+    Example
+    =======
+    ::
+
+        {
+          "1611082554": {
+            "temperature": 21.42,
+            "humidity": 41.55
+          },
+          "1611082568": {
+            "temperature": 42.84,
+            "humidity": 83.1
+          }
+        }
+
+    """
+
+    @staticmethod
+    def decode(payload):
+
+        # Decode from JSON.
+        message = json.loads(payload)
+
+        # Create list of data dictionaries.
+        data = []
+        for timestamp, item in message.items():
+            item["time"] = timestamp
+            data.append(item)
+
+        return data

--- a/test/settings/mqttkit.py
+++ b/test/settings/mqttkit.py
@@ -27,6 +27,7 @@ class TestSettings:
     mqtt_topic3_json   = 'mqttkit-1/itest3/foo/bar/data.json'
     mqtt_topic_event  = 'mqttkit-1/itest/foo/bar/event.json'
     mqtt_topic_homie  = 'mqttkit-1/itest/foo/bar/data/__json__'
+    mqtt_topic_json_compact = 'mqttkit-1/itest/foo/bar/tc.json'
     mqtt_topic_json_legacy = 'mqttkit-1/itest/foo/bar/message-json'
 
     # HTTP channel settings.


### PR DESCRIPTION
Coming from #39 and building upon #40, this implements the acquisition of bulk readings in compact JSON format as needed by @valentinbarral. The "compact JSON" format is currently defined with timestamps as keys.

An example payload is:
```json
{
  "1611082554": {
    "temperature": 21.42,
    "humidity": 41.55
  },
  "1611082568": {
    "temperature": 42.84,
    "humidity": 83.1
  }
}
```

Instead of submitting data to the `/data.json` MQTT topic suffix, this "compact JSON" format is decoded on the `/tc.json` MQTT topic suffix. `"tc.json"` in this context means "_timestamped compact json_".
