### PR TITLE
Expand CI to run different versions of Mosquitto, InfluxDB and Grafana

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         os: [ ubuntu-latest ] # , macos-latest, windows-latest ]
         python-version: [ "3.6", "3.7", "3.8" ]
+        mosquitto-version: [ "1.5", "1.6" ] #, "2.0" ]
+        influxdb-version: [ "1.7", "1.8" ]
+        grafana-version: [ "5.4.5", "6.7.6", "7.5.10" ] # "8.1.0-beta2" ]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip
@@ -26,19 +29,19 @@ jobs:
 
       # TODO: Maybe use https://github.com/marketplace/actions/mosquitto-mqtt-broker-in-github-actions
       mosquitto:
-        image: eclipse-mosquitto:1.6
+        image: eclipse-mosquitto:${{ matrix.mosquitto-version }}
         ports:
           - 1883:1883
           - 9001:9001
 
       influxdb:
-        image: influxdb:1.8
+        image: influxdb:${{ matrix.influxdb-version }}
         ports:
           - 8083:8083
           - 8086:8086
 
       grafana:
-        image: grafana/grafana:7.4.5
+        image: grafana/grafana:${{ matrix.grafana-version }}
         ports:
           - 3000:3000
         env:
@@ -53,7 +56,7 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
 
-    name: Python ${{ matrix.python-version }} on OS ${{ matrix.os }}
+    name: OS ${{ matrix.os }}, Python ${{ matrix.python-version }}, Mosquitto ${{ matrix.mosquitto-version }}, InfluxDB ${{ matrix.influxdb-version }}, Grafana ${{ matrix.grafana-version }}
     steps:
 
       - name: Acquire sources

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 
 in progress
 ===========
+- Expand CI to run tests against different versions of Mosquitto, InfluxDB and Grafana
 
 - Stop running tests for Python 3.5 on CI
 - Improve tests on HTTP API for data acquisition

--- a/test/test_airrohr.py
+++ b/test/test_airrohr.py
@@ -90,6 +90,7 @@ def test_airrohr_http_json(machinery, create_influxdb, reset_influxdb):
 
     # Wait for some time to process the message.
     yield sleep(PROCESS_DELAY_MQTT)
+    yield sleep(PROCESS_DELAY_MQTT)
 
     # Proof that data arrived in InfluxDB.
     record = influx_sensors.get_first_record()


### PR DESCRIPTION
Hi there,

in order to improve QA, let's run the test suite on top of different versions of Mosquitto, InfluxDB and Grafana.

With kind regards,
Andreas.