### PR TITLE
CI: Use Grafana 8.1.0 GA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: [ "3.6", "3.7", "3.8", "3.9" ]
         mosquitto-version: [ "1.6" ] #, "2.0" ]
         influxdb-version: [ "1.7", "1.8" ]
-        grafana-version: [ "6.7.6", "7.5.10", "8.1.0-beta3" ]
+        grafana-version: [ "6.7.6", "7.5.10", "8.1.0" ]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip


### PR DESCRIPTION
Grafana 8.1.0 has been released today, see https://github.com/grafana/grafana/blob/main/CHANGELOG.md#810-2021-08-05.