### PR TITLE
Modernize packaging

### DIFF
--- a/doc/source/development/releasing/packaging.rst
+++ b/doc/source/development/releasing/packaging.rst
@@ -12,11 +12,41 @@ Packaging
 Prerequisites
 *************
 
+The package build system is based on `Docker`_, please read the documentation
+at `Install Docker`_ how to set it up on your system.
+
+For example, on Debian 11 (bullseye), you would install it like this::
+
+    # Acquire package signing key.
+    wget -qO - https://download.docker.com/linux/debian/gpg | apt-key add -
+
+    # Register with package repository.
+    echo "deb [arch=amd64] https://download.docker.com/linux/debian bullseye stable" > /etc/apt/sources.list.d/docker.list
+    apt-get update
+
+    # Install Docker.
+    apt-get install docker-ce
+
+After installing Docker, some additional packages are needed::
+
+    apt-get install python3 python3-venv git make qemu-user-static binfmt-support
+
+Then, get hold of the sources and install a minimum part of the sandbox::
+
+    git clone https://github.com/daq-tools/kotori
+    cd kotori
+    make install-releasetools
+
+
+***************
+Baseline images
+***************
+
 Prepare baseline Docker images::
 
     make package-baseline-images
 
-Prepare dependency wheel packages::
+Optionally, prepare dependency wheel packages (most users can skip this step)::
 
     ./packaging/wheels/build.sh
     ./packaging/wheels/upload.sh
@@ -79,3 +109,7 @@ Run basic QA checks::
 Designate specific version as ``latest``::
 
     make package-docker-link version=0.26.6 tag=latest
+
+
+.. _Docker: https://docker.com/
+.. _Install Docker: https://docs.docker.com/get-docker/

--- a/packaging/dockerfiles/debian-baseline.dockerfile
+++ b/packaging/dockerfiles/debian-baseline.dockerfile
@@ -32,7 +32,7 @@ RUN apt-get install --yes --no-install-recommends \
     ruby ruby-dev
 
 # Install fpm (Effing package management).
-RUN gem install fpm --version=1.12.0
+RUN gem install fpm --version=1.14.1
 
 
 FROM debian-fpm

--- a/tasks/packaging/environment.py
+++ b/tasks/packaging/environment.py
@@ -15,9 +15,9 @@ class DockerBaselineImageBuilder:
             enabled=True,
             vendor="Debian",
             distributions=[
-                "stretch",
+                "bullseye",
                 "buster",
-                # "bullseye",
+                "stretch",
             ],
             architectures=[
                 "amd64",
@@ -31,8 +31,8 @@ class DockerBaselineImageBuilder:
             enabled=True,
             vendor="Ubuntu",
             distributions=[
-                "bionic",
                 "focal",
+                "bionic",
             ],
             architectures=[
                 "amd64",
@@ -41,7 +41,7 @@ class DockerBaselineImageBuilder:
         ),
     ]
 
-    docker_image_version = "0.10.0"
+    docker_image_version = "0.11.0"
 
     def run(self):
         """

--- a/tasks/packaging/environment.py
+++ b/tasks/packaging/environment.py
@@ -66,6 +66,7 @@ class DockerBaselineImageBuilder:
                     commands = [
                         f"""
                         docker build \
+                            --pull \
                             --tag ephemeral/{distribution}-{architecture}-baseline:{self.docker_image_version} \
                             --tag ephemeral/{distribution}-{architecture}-baseline:latest \
                             --build-arg BASE_IMAGE={image} - \

--- a/tasks/packaging/ospackage.py
+++ b/tasks/packaging/ospackage.py
@@ -19,10 +19,8 @@ class PackageBuilder:
             enabled=True,
             architecture="amd64",
             distributions=[
-                "stretch",
-                "buster",
-                "bionic",
-                "focal",
+                "bullseye", "buster", "stretch",
+                "focal", "bionic",
             ],
             flavors=[
                 "full",
@@ -33,8 +31,9 @@ class PackageBuilder:
             enabled=True,
             architecture="arm64v8",
             distributions=[
-                "stretch",  # ImportError: cannot import name '_BACKCOMPAT_MAGIC_NUMBER'
+                "bullseye",
                 "buster",
+                "stretch",  # ImportError: cannot import name '_BACKCOMPAT_MAGIC_NUMBER'
             ],
             flavors=["standard"],
         ),
@@ -42,8 +41,9 @@ class PackageBuilder:
             enabled=True,
             architecture="arm32v7",
             distributions=[
-                "stretch",  # ImportError: cannot import name '_BACKCOMPAT_MAGIC_NUMBER'
+                "bullseye",
                 "buster",
+                "stretch",  # ImportError: cannot import name '_BACKCOMPAT_MAGIC_NUMBER'
             ],
             flavors=["standard"],
         ),


### PR DESCRIPTION
Hi there,

this patch was conceived while working on #64. It improves some details on the packaging side.

- Upgrade `fpm` to most recent version 1.14.1
- Add packaging for Debian 11 (bullseye)
- Run `docker build --pull` to always use the latest upstrem images
- Improve documentation

With kind regards,
Andreas.
