### PR TITLE
Improve MQTT connection logging and credential configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ in progress
 ===========
 - Add basic information about RabbitMQ
 - Improve MQTT logging when connection to broker fails
+- Make MQTT broker credential settings ``username`` and ``password`` optional
 
 
 .. _kotori-0.26.12:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 
 in progress
 ===========
+- Add basic information about RabbitMQ
 
 
 .. _kotori-0.26.12:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 in progress
 ===========
 - Add basic information about RabbitMQ
+- Improve MQTT logging when connection to broker fails
 
 
 .. _kotori-0.26.12:

--- a/doc/source/setup/rabbitmq.rst
+++ b/doc/source/setup/rabbitmq.rst
@@ -1,0 +1,23 @@
+############################
+Running Kotori with RabbitMQ
+############################
+
+Instead of Mosquitto, Kotori can be used together with `RabbitMQ`_ and its
+`MQTT Plugin`_.
+
+This is a basic description how to run RabbitMQ using Docker, in order to
+verify the functionality.
+
+::
+
+    docker build --tag=rabbitmq-mqtt - < packaging/dockerfiles/rabbitmq.dockerfile
+
+::
+
+    docker run -it --rm --publish=1883:1883 --publish=15672:15672 rabbitmq-mqtt
+
+Visit http://localhost:15672/ and log in with guest / guest.
+
+
+.. _MQTT Plugin: https://www.rabbitmq.com/mqtt.html
+.. _RabbitMQ: https://www.rabbitmq.com/

--- a/etc/development.ini
+++ b/etc/development.ini
@@ -20,8 +20,8 @@ http_port   = 24642
 [mqtt]
 host        = localhost
 #port        = 1883
-username    = kotori
-password    = kotori
+#username    = kotori
+#password    = kotori
 
 ; wamp bus adapter
 [wamp]

--- a/etc/docker.ini
+++ b/etc/docker.ini
@@ -19,8 +19,8 @@ http_port   = 24642
 [mqtt]
 host        = mosquitto
 #port        = 1883
-username    = kotori
-password    = kotori
+#username    = kotori
+#password    = kotori
 
 ; wamp bus adapter
 [wamp]

--- a/etc/production.ini
+++ b/etc/production.ini
@@ -20,8 +20,8 @@ http_port   = 24642
 [mqtt]
 host        = localhost
 #port        = 1883
-username    = kotori
-password    = kotori
+#username    = kotori
+#password    = kotori
 
 ; wamp bus adapter
 [wamp]

--- a/kotori/daq/services/mig.py
+++ b/kotori/daq/services/mig.py
@@ -62,8 +62,8 @@ class MqttInfluxGrafanaService(MultiService, MultiServiceMixin):
             name          = u'mqtt-' + self.channel.realm,
             broker_host   = self.settings.mqtt.host,
             broker_port   = int(self.settings.mqtt.port),
-            broker_username = self.settings.mqtt.username,
-            broker_password = self.settings.mqtt.password,
+            broker_username = self.settings.mqtt.get("username"),
+            broker_password = self.settings.mqtt.get("password"),
             callback      = self.mqtt_receive,
             subscriptions = subscriptions)
 

--- a/packaging/dockerfiles/rabbitmq.dockerfile
+++ b/packaging/dockerfiles/rabbitmq.dockerfile
@@ -1,0 +1,2 @@
+FROM rabbitmq:3.9
+RUN rabbitmq-plugins enable --offline rabbitmq_management rabbitmq_mqtt


### PR DESCRIPTION
This patch brings in some improvements related to #72. Most importantly, connection failures to the MQTT broker will be logged (af268ec). Also, it makes the MQTT broker credential settings ``username`` and ``password`` optional (2814c8d). On top of that, some information about running RabbitMQ through Docker have been added (46de437).
