### PR TITLE
Improve test harness

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,14 +72,16 @@ jobs:
 
       - name: Apply caching of dependencies
         uses: actions/cache@v2
+        env:
+          # Increase this value to reset cache even if the output from `hashFiles()` has not changed.
+          CACHE_NUMBER: 1
         with:
           path: ${{ matrix.path }}
-          key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ hashFiles('setup.py', 'requirements-test.txt', 'requirements-docs.txt') }}
-          restore-keys: |
-           ${{ runner.os }}-pip-
+          key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ hashFiles('setup.py', 'requirements-test.txt', 'requirements-docs.txt') }}-${{ env.CACHE_NUMBER }}
 
       - name: Install program
         run: |
+          pip install wheel
           pip install --requirement=requirements-test.txt
           pip install --editable=.[daq,daq_geospatial,export,scientific,firmware]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,8 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
 
-    name: OS ${{ matrix.os }}, Python ${{ matrix.python-version }}, Mosquitto ${{ matrix.mosquitto-version }}, InfluxDB ${{ matrix.influxdb-version }}, Grafana ${{ matrix.grafana-version }}
+    #name: OS ${{ matrix.os }}, Python ${{ matrix.python-version }}, Mosquitto ${{ matrix.mosquitto-version }}, InfluxDB ${{ matrix.influxdb-version }}, Grafana ${{ matrix.grafana-version }}
+    name: Python ${{ matrix.python-version }}, Mosquitto ${{ matrix.mosquitto-version }}, InfluxDB ${{ matrix.influxdb-version }}, Grafana ${{ matrix.grafana-version }}
     steps:
 
       - name: Acquire sources

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ check-ptrace-options:
 # ==============
 
 start-foundation-services:
+	docker-compose pull
 	docker-compose up
 
 mongodb-start:

--- a/etc/test/basic.ini
+++ b/etc/test/basic.ini
@@ -2,10 +2,7 @@
 ;          Kotori test configuration
 ; ##########################################
 [main]
-include     =
-              etc/examples/mqttkit.ini,
-              etc/examples/forwarders/http-api-generic.ini,
-              etc/examples/forwarders/http-api-export.ini
+include     = etc/examples/basic.ini
 
 
 ; ==========================================

--- a/kotori/core.py
+++ b/kotori/core.py
@@ -29,10 +29,12 @@ APP_NAME = u'Kotori version ' + __VERSION__
 
 # TODO: introduce kotori.core.boot_component(s)
 
+
 class KotoriBootloader(object):
 
     def __init__(self, settings=None):
         self.settings = settings
+        self.applications = []
 
     def boot_applications(self):
         """
@@ -41,7 +43,9 @@ class KotoriBootloader(object):
         applications = list(self.get_applications())
         log.info(u'Enabling applications {applications}', applications=applications)
         for name in applications:
-            self.boot_application(name)
+            app = self.boot_application(name)
+            if app is not None:
+                self.applications.append(app)
 
     def boot_application(self, name):
         """
@@ -59,6 +63,7 @@ class KotoriBootloader(object):
             application_settings = self.settings[name]
             application = factory(name=name, application_settings=application_settings, global_settings=self.settings)
             application.startService()
+            return application
         except Exception as ex:
             log.failure('Error running application factory "{name}":\n{log_failure}', name=name)
             return

--- a/kotori/daq/application/mqttkit.py
+++ b/kotori/daq/application/mqttkit.py
@@ -33,6 +33,7 @@ class MqttKitApplication(RootService):
             )
 
         # Register service component with its container
+        log.info('Registering service "{service}" with name "{name}"', service=service, name=self.name)
         self.registerService(service)
 
 

--- a/kotori/daq/graphing/grafana/api.py
+++ b/kotori/daq/graphing/grafana/api.py
@@ -101,9 +101,9 @@ class GrafanaApi(object):
         """
 
         try:
-            log.info(u'Checking/Creating datasource "{}"'.format(name))
+            log.info('Checking/creating datasource "{name}" with "{data}"', name=name, data=data)
             response = self.grafana_client.datasources.create(**data)
-            log.info('response: {response}', response=response)
+            log.info('Grafana response: {response}', response=response)
         except GrafanaServerError as ex:
             message = str(ex)
             if 'Failed to add datasource' in message:
@@ -119,7 +119,6 @@ class GrafanaApi(object):
                 raise
 
         #print grafana.datasources()
-
 
     def create_dashboard(self, dashboard, name=None, delete=False):
 

--- a/kotori/daq/graphing/grafana/manager.py
+++ b/kotori/daq/graphing/grafana/manager.py
@@ -28,9 +28,10 @@ class GrafanaManager(MultiService, MultiServiceMixin):
         if not 'port' in self.config['grafana']:
             self.config['grafana']['port'] = '3000'
 
-        name = self.__class__.__name__
+        self.name = 'grafana-manager-{realm}-{id}'.format(realm=self.channel.get('realm'), id=str(id(self)))
+
         log.info('Starting GrafanaManager "{}". grafana={}:{}'.format(
-            name,
+            self.name,
             self.config['grafana']['host'],
             self.config['grafana']['port']))
 

--- a/kotori/daq/intercom/mqtt/paho.py
+++ b/kotori/daq/intercom/mqtt/paho.py
@@ -86,13 +86,11 @@ class PahoMqttAdapter(BaseMqttAdapter, Service):
         metadata = "userdata={userdata}, flags={flags}, rc={rc}, properties={properties}".format(
             userdata=userdata, flags=flags, rc=rc, properties=properties)
 
-        metadata = metadata.replace("{", "{{").replace("}", "}}")
-
         errmsg = get_connect_error(rc)
         if rc == mqtt.CONNACK_ACCEPTED:
-            log.info("MQTT connection succeeded: {errmsg} ({metadata})".format(errmsg=errmsg, metadata=metadata))
+            log.info("MQTT connection succeeded: {errmsg} ({metadata})", errmsg=errmsg, metadata=metadata)
         else:
-            log.error("MQTT connection failed: {errmsg} ({metadata})".format(errmsg=errmsg, metadata=metadata))
+            log.error("MQTT connection failed: {errmsg} ({metadata})", errmsg=errmsg, metadata=metadata)
             return
 
         # Subscribing in on_connect() means that if we lose the connection and
@@ -139,11 +137,13 @@ class PahoMqttAdapter(BaseMqttAdapter, Service):
         return self.client.publish(topic, payload)
 
     def subscribe(self, *args):
-        #d = self.protocol.subscribe("foo/bar/baz", 0)
+        if not self.subscriptions:
+            return
         log.info(u"Subscribing to topics {subscriptions}. client={client}", subscriptions=self.subscriptions, client=self.client)
         for topic in self.subscriptions:
             log.info(u"Subscribing to topic '{topic}'", topic=topic)
             # Topic name **must not** be unicode, so casting to string
+            # TODO: Evaluate return value.
             e = self.client.subscribe(str(topic), qos=0)
 
     def on_log(self, client, userdata, level, buf):

--- a/kotori/daq/services/mig.py
+++ b/kotori/daq/services/mig.py
@@ -45,13 +45,14 @@ class MqttInfluxGrafanaService(MultiService, MultiServiceMixin):
         self.log(log.info, u'Bootstrapping')
         self.settings = self.parent.settings
 
-        # Optionally register subsystem component as child service
+        # Register subsystem components as child services.
         for subsystem in self.subsystems:
             if hasattr(self, subsystem):
-                subsystem_service = getattr(self, subsystem)
-                if isinstance(subsystem_service, Service):
-                    log.info('Registering subsystem component "{subsystem}" as service', subsystem=subsystem)
-                    self.registerService(subsystem_service)
+                subsystem_services = to_list(getattr(self, subsystem))
+                for service in subsystem_services:
+                    if isinstance(service, Service):
+                        log.info('Registering subsystem component "{subsystem}" as service at name "{name}"', subsystem=subsystem, name=service.name)
+                        self.registerService(service)
 
         # Configure metrics to be collected each X seconds
         metrics_interval = int(self.channel.get('metrics_logger_interval', 60))

--- a/kotori/util/common.py
+++ b/kotori/util/common.py
@@ -181,3 +181,7 @@ class KeyCache(object):
     def exists(self, *args):
         skip_key = self._get_skip_key(*args)
         return skip_key in self.storage
+
+    def reset(self):
+        logger.info("GrafanaManager: Resetting key cache")
+        self.storage = {}

--- a/kotori/util/configuration.py
+++ b/kotori/util/configuration.py
@@ -41,7 +41,7 @@ def get_configuration(*args):
                     config_files.append(include)
             log.info('Expanded configuration files:  {}'.format(make_list(config_files)))
             config, used = read_config(config_files, kind=Bunch)
-        log.info('Used configuration files:      {}'.format(make_list(used)))
+        log.info('Effective configuration files: {}'.format(make_list(used)))
         return config
     else:
         msg = u'Could not read settings from configuration files: {}'.format(config_files)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,8 +7,6 @@ https://docs.pytest.org/en/latest/fixture.html#conftest-py-sharing-fixture-funct
 import pytest
 import logging
 
-import pytest_twisted
-
 from kotori import KotoriBootloader
 from test.util import boot_kotori
 from test.settings.mqttkit import influx_sensors, influx_events, grafana
@@ -48,5 +46,6 @@ machinery = create_machinery('./etc/test/main.ini')
 create_influxdb = influx_sensors.make_create_db()
 reset_influxdb = influx_sensors.make_reset_measurement()
 reset_grafana = grafana.make_reset()
-
 reset_influxdb_events = influx_events.make_reset_measurement()
+
+machinery_basic = create_machinery('./etc/test/basic.ini')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,6 +37,8 @@ def create_machinery(config, scope="package"):
         assert isinstance(result, KotoriBootloader)
 
         #pytest_twisted.blockon(result)
+
+        logger.info('Machinery is almost ready')
         yield result
 
     return machinery

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 def create_machinery(config, scope="package"):
 
-    @pytest_twisted.inlineCallbacks
+    #@pytest_twisted.inlineCallbacks
     @pytest.fixture(scope=scope)
     def machinery():
 

--- a/test/settings/basic.py
+++ b/test/settings/basic.py
@@ -3,7 +3,7 @@
 
 from test.util import InfluxWrapper, GrafanaWrapper
 
-PROCESS_DELAY_MQTT = 0.2
+PROCESS_DELAY_MQTT = 0.3
 
 
 class BasicSettings:

--- a/test/settings/mqttkit.py
+++ b/test/settings/mqttkit.py
@@ -3,8 +3,8 @@
 
 from test.util import InfluxWrapper, GrafanaWrapper
 
-PROCESS_DELAY_MQTT = 0.2
-PROCESS_DELAY_HTTP = 0.2
+PROCESS_DELAY_MQTT = 0.3
+PROCESS_DELAY_HTTP = 0.3
 
 
 class TestSettings:

--- a/test/test_airrohr.py
+++ b/test/test_airrohr.py
@@ -6,8 +6,7 @@ import pytest
 import pytest_twisted
 from twisted.internet import threads
 
-from test.conftest import create_machinery
-from test.settings.basic import settings, influx_sensors, grafana, create_influxdb, reset_influxdb, reset_grafana, PROCESS_DELAY_MQTT
+from test.settings.basic import settings, influx_sensors, create_influxdb, reset_influxdb, reset_grafana, PROCESS_DELAY_MQTT
 from test.util import http_json_sensor, sleep
 
 logger = logging.getLogger(__name__)
@@ -73,16 +72,10 @@ data_out = {
 }
 
 
-machinery = create_machinery('./etc/test/basic.ini')
-
-create_influxdb = influx_sensors.make_create_db()
-reset_influxdb = influx_sensors.make_reset_measurement()
-
-
 @pytest_twisted.inlineCallbacks
 @pytest.mark.http
 @pytest.mark.airrohr
-def test_airrohr_http_json(machinery, create_influxdb, reset_influxdb):
+def test_airrohr_http_json(machinery_basic, create_influxdb, reset_influxdb):
     """
     Submit single reading in Airrohr JSON format to HTTP API
     and proof it is stored in the InfluxDB database.
@@ -92,6 +85,7 @@ def test_airrohr_http_json(machinery, create_influxdb, reset_influxdb):
     yield threads.deferToThread(http_json_sensor, settings.channel_path_airrohr, data_in)
 
     # Wait for some time to process the message.
+    yield sleep(PROCESS_DELAY_MQTT)
     yield sleep(PROCESS_DELAY_MQTT)
 
     # Proof that data arrived in InfluxDB.

--- a/test/test_airrohr.py
+++ b/test/test_airrohr.py
@@ -6,6 +6,7 @@ import pytest
 import pytest_twisted
 from twisted.internet import threads
 
+from test.conftest import create_machinery
 from test.settings.basic import settings, influx_sensors, grafana, create_influxdb, reset_influxdb, reset_grafana, PROCESS_DELAY_MQTT
 from test.util import http_json_sensor, sleep
 
@@ -72,6 +73,8 @@ data_out = {
 }
 
 
+machinery = create_machinery('./etc/test/basic.ini')
+
 create_influxdb = influx_sensors.make_create_db()
 reset_influxdb = influx_sensors.make_reset_measurement()
 
@@ -89,9 +92,6 @@ def test_airrohr_http_json(machinery, create_influxdb, reset_influxdb):
     yield threads.deferToThread(http_json_sensor, settings.channel_path_airrohr, data_in)
 
     # Wait for some time to process the message.
-    yield sleep(PROCESS_DELAY_MQTT)
-    yield sleep(PROCESS_DELAY_MQTT)
-    yield sleep(PROCESS_DELAY_MQTT)
     yield sleep(PROCESS_DELAY_MQTT)
 
     # Proof that data arrived in InfluxDB.

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -23,6 +23,11 @@ def test_mqtt_strategy_lan(machinery, create_influxdb, reset_influxdb, reset_gra
     that a corresponding datasource and a dashboard was created in Grafana.
     """
 
+    # Wait for some time to spin up the machinery.
+    yield sleep(PROCESS_DELAY_MQTT)
+    yield sleep(PROCESS_DELAY_MQTT)
+    yield sleep(PROCESS_DELAY_MQTT)
+
     # Submit a single measurement, without timestamp.
     data = {
         'temperature': 42.84,

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -32,6 +32,8 @@ def test_mqtt_strategy_lan(machinery, create_influxdb, reset_influxdb, reset_gra
 
     # Wait for some time to process the message.
     yield sleep(PROCESS_DELAY_MQTT)
+    yield sleep(PROCESS_DELAY_MQTT)
+    yield sleep(PROCESS_DELAY_MQTT)
 
     # Proof that data arrived in InfluxDB.
     record = influx_sensors.get_first_record()

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -5,10 +5,13 @@ import logging
 import pytest
 import pytest_twisted
 
+from test.conftest import create_machinery
 from test.settings.basic import settings, influx_sensors, grafana, create_influxdb, reset_influxdb, reset_grafana, PROCESS_DELAY_MQTT
 from test.util import mqtt_json_sensor, sleep
 
 logger = logging.getLogger(__name__)
+
+machinery = create_machinery('./etc/test/basic.ini')
 
 
 @pytest_twisted.inlineCallbacks
@@ -28,8 +31,6 @@ def test_mqtt_strategy_lan(machinery, create_influxdb, reset_influxdb, reset_gra
     yield mqtt_json_sensor(settings.mqtt_topic_json, data)
 
     # Wait for some time to process the message.
-    yield sleep(PROCESS_DELAY_MQTT)
-    yield sleep(PROCESS_DELAY_MQTT)
     yield sleep(PROCESS_DELAY_MQTT)
 
     # Proof that data arrived in InfluxDB.

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -5,19 +5,16 @@ import logging
 import pytest
 import pytest_twisted
 
-from test.conftest import create_machinery
 from test.settings.basic import settings, influx_sensors, grafana, create_influxdb, reset_influxdb, reset_grafana, PROCESS_DELAY_MQTT
 from test.util import mqtt_json_sensor, sleep
 
 logger = logging.getLogger(__name__)
 
-machinery = create_machinery('./etc/test/basic.ini')
-
 
 @pytest_twisted.inlineCallbacks
 @pytest.mark.mqtt
 @pytest.mark.grafana
-def test_mqtt_strategy_lan(machinery, create_influxdb, reset_influxdb, reset_grafana):
+def test_mqtt_strategy_lan(machinery_basic, create_influxdb, reset_influxdb, reset_grafana):
     """
     Publish single reading in JSON format to MQTT broker and proof
     that a corresponding datasource and a dashboard was created in Grafana.

--- a/test/test_daq_http.py
+++ b/test/test_daq_http.py
@@ -37,6 +37,7 @@ def test_http_json_valid(machinery, create_influxdb, reset_influxdb):
 
     # Wait for some time to process the message.
     yield sleep(PROCESS_DELAY_HTTP)
+    yield sleep(PROCESS_DELAY_HTTP)
 
     # Proof that data arrived in InfluxDB.
     record = influx_sensors.get_first_record()

--- a/test/test_vendor_hiveeyes.py
+++ b/test/test_vendor_hiveeyes.py
@@ -50,14 +50,15 @@ def test_mqtt_to_grafana(machinery_hiveeyes, create_influxdb_hiveeyes, reset_inf
     # Wait for some time to process the message.
     yield sleep(PROCESS_DELAY_MQTT)
 
-    # Wait for Grafana to create its artefacts.
-    yield sleep(2)
-
     # Proof that data arrived in InfluxDB.
     record = influx.get_first_record()
     del record['time']
     assert record == {u'temperature': 42.84, u'weight': 33.33}
     yield record
+
+    # Wait for Grafana to create its artefacts.
+    yield sleep(PROCESS_DELAY_MQTT)
+    yield sleep(PROCESS_DELAY_MQTT)
 
     # Proof that Grafana is well provisioned.
     logger.info('Grafana: Checking datasource')


### PR DESCRIPTION
While investigating #70, we needed to improve the test harness. Now, it doesn't invoke _two_ realms on each test invocation. Instead, it separates between `basic` and `mqttkit`. Also, the `reset_grafana` fixture will clear `GrafanaManager`s key cache now.