### PR TITLE
Configure MQTT broker per application

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,8 @@ in progress
 
 2022-11-26 0.27.0
 =================
-- Add documentation about running Kotori with RabbitMQ as MQTT broker, see :ref:`mqtt-broker-rabbitmq`.
+- Add documentation about running Kotori with RabbitMQ as MQTT broker, see :ref:`mqtt-broker-rabbitmq`
+- Allow connecting to individual MQTT broker per application
 - Improve MQTT logging when connection to broker fails
 - Make MQTT broker credential settings ``username`` and ``password`` optional
 - Add software tests for simulating all advanced actions against Grafana

--- a/doc/source/handbook/configuration/mqttkit.rst
+++ b/doc/source/handbook/configuration/mqttkit.rst
@@ -23,18 +23,36 @@ Configuration
 *************
 .. highlight:: ini
 
+
+Application section
+===================
+
 The core of each data acquisition application is its configuration object.
 The file :download:`etc/examples/mqttkit.ini <../../_static/content/etc/examples/mqttkit.ini>`
 can be used as a configuration blueprint.
 
-This configuration snippet will create an
-application object defined as ``[mqttkit-1]``.
+This configuration snippet will create an application object defined as ``[mqttkit-1]``.
 
 .. literalinclude:: ../../_static/content/etc/examples/mqttkit.ini
     :language: ini
     :linenos:
     :lines: 1-16
     :emphasize-lines: 10-15
+
+
+Multiple MQTT brokers
+=====================
+
+It is possible to make Kotori connect to an individual MQTT broker per application.
+On behalf of this example, you would create a separate configuration section
+``[mqttkit-1:mqtt]``, where ``mqttkit-1`` reflects the value of the ``realm``
+attribute of the main application settings section.
+
+.. literalinclude:: ../../_static/content/etc/examples/mqttkit.ini
+    :language: ini
+    :linenos:
+    :lines: 10-27
+    :emphasize-lines: 4,11-18
 
 
 **********

--- a/etc/examples/mqttkit.ini
+++ b/etc/examples/mqttkit.ini
@@ -17,6 +17,15 @@ application = kotori.daq.application.mqttkit:mqttkit_application
 # How often to log metrics
 metrics_logger_interval = 60
 
+# [mqttkit-1:mqtt]
+# ; Configure individual MQTT broker for this application.
+# ; The option group prefix `mqttkit-1` reflects the value of
+# ; the `realm` attribute of the application settings.
+# host        = mqtt.example.org
+# port        = 1883
+# username    = foobar
+# password    = secret
+
 
 [mqttkit-2]
 enable      = false

--- a/kotori/util/configuration.py
+++ b/kotori/util/configuration.py
@@ -86,7 +86,7 @@ def make_list(items, separator=u', '):
 def apply_default_settings(settings):
 
     # MQTT setting defaults
-    settings.mqtt.setdefault('host', u'localhost')
-    settings.mqtt.setdefault('port', u'1883')
-    settings.mqtt.setdefault('debug', u'false')
-
+    if "mqtt" in settings:
+        settings.mqtt.setdefault('host', u'localhost')
+        settings.mqtt.setdefault('port', u'1883')
+        settings.mqtt.setdefault('debug', u'false')


### PR DESCRIPTION
Hi there,

as requested at #82, this patch makes Kotori optionally connect to an individual MQTT broker per application.

With kind regards,
Andreas.

/cc @tonkenfo