### PR TITLE
Update to Twisted 22.1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ in progress
   ``name`` and ``title`` fields.
 - CI: Use Grafana 8.2.5
 - Improve decoding fractional epoch timestamps
+- Update to Twisted 22.1.0
 
 
 .. _kotori-0.26.12:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if PYTHON_35:
 requires = [
 
     # Core
-    'Twisted[tls]==20.3.0',
+    'Twisted[tls]==22.1.0',
     'pyOpenSSL>=16.2.0',
     'six>=1.15.0',
     'pyramid==1.9.4',


### PR DESCRIPTION
Update to most recent version of [Twisted], because GHSA-92x2-jw7w-xvvx.

[Twisted]: https://pypi.org/project/Twisted/