### PR TITLE
CI: Update to Grafana 9.0.0-beta1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
           GF_SECURITY_ADMIN_PASSWORD: admin
 
       mongodb:
-        image: mongo:4.4
+        image: mongo:5
         ports:
           - 27017:27017
 
@@ -54,7 +54,7 @@ jobs:
     steps:
 
       - name: Acquire sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Start Mosquitto
         uses: namoshek/mosquitto-github-action@v1
@@ -66,7 +66,7 @@ jobs:
           # container-name: 'mqtt'
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: [ "3.6", "3.7", "3.8", "3.9" ]
         mosquitto-version: [ "1.6", "2.0" ]
         influxdb-version: [ "1.7", "1.8" ]
-        grafana-version: [ "6.7.6", "7.5.15", "8.4.5" ]
+        grafana-version: [ "6.7.6", "7.5.16", "8.5.3", "9.0.0-beta1" ]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,7 @@ in progress
   ``name`` and ``title`` fields.
 - Improve decoding fractional epoch timestamps
 - Update to Twisted 22.2.0
-- CI: Update to Grafana 7.5.15 and 8.4.5
+- CI: Update to Grafana 7.5.16, 8.5.3 and 9.0.0
 - CI: Update to MongoDB 5.0
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ in progress
   will now use the slug-name of the data channel for all of Grafana's ``uid``,
   ``name`` and ``title`` fields.
 - Improve decoding fractional epoch timestamps
-- Update to Twisted 22.2.0
+- Update to Twisted 22.4.0
 - CI: Update to Grafana 7.5.16, 8.5.3 and 9.0.0
 - CI: Update to MongoDB 5.0
 

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Kotori
         :target: https://github.com/eclipse/mosquitto
         :alt: Supported Mosquitto versions
 
-  .. image:: https://img.shields.io/badge/Grafana-5.x%20--%208.x-blue.svg
+  .. image:: https://img.shields.io/badge/Grafana-5.x%20--%209.x-blue.svg
         :target: https://github.com/grafana/grafana
         :alt: Supported Grafana versions
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if PYTHON_35:
 requires = [
 
     # Core
-    'Twisted[tls]==22.2.0',
+    'Twisted[tls]==22.4.0',
     'pyOpenSSL>=16.2.0',
     'six>=1.15.0',
     'pyramid==1.10.8',


### PR DESCRIPTION
- CI: Test against Grafana 9.0.0-beta1, which was released a few hours ago.
- Upgrade Twisted to fix https://github.com/advisories/GHSA-c2jg-hw38-jrqq.
