### PR TITLE
Stop converging `latitude` and `longitude` ingress fields to tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,14 @@ in progress
 - Documentation: Update to Sphinx 5
 
 
+Breaking changes
+----------------
+- Stop converging ``latitude`` and ``longitude`` ingress fields to tags.
+  It has been implemented as a convenience case when processing LDI data,
+  but it is not applicable in standard data acquisition scenarios, specifically
+  when recording positions of moving objects. Thanks, @tonkenfo.
+
+
 .. _kotori-0.26.12:
 
 2021-10-11 0.26.12

--- a/kotori/daq/storage/influx.py
+++ b/kotori/daq/storage/influx.py
@@ -194,12 +194,6 @@ class InfluxDBAdapter(object):
             chunk["tags"]["geohash"] = data["geohash"]
             del data['geohash']
 
-        if "latitude" in data and "longitude" in data:
-            chunk["tags"]["latitude"] = data["latitude"]
-            chunk["tags"]["longitude"] = data["longitude"]
-            del data['latitude']
-            del data['longitude']
-
         # Extract more information specific to luftdaten.info
         for field in ['location', 'location_id', 'location_name', 'sensor_id', 'sensor_type']:
             if field in data:


### PR DESCRIPTION
Hi there,

this patch reverts ef8c6ff4b and resolves #31 and #65.

It has been implemented as a convenience case when processing LDI data, but it is not applicable in standard data acquisition scenarios, specifically when recording positions of moving objects.

With kind regards,
Andreas.

/cc @tonkenfo, @einsiedlerkrebs 