### PR TITLE
[DRAFT] DAQ: Assume naive human-readable timestamps w/o timezone information to be in UTC

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ in progress
 - General: Dropped support for Python 3.7
 - DAQ: Masked ``PASSKEY`` variable coming from HTTP, emitted by Ecowitt
 
+Breaking changes
+----------------
+
+- DAQ: Obtain naive timestamps as UTC by default, instead of CET
+
 .. _kotori-0.28.1:
 
 2026-02-27 0.28.1

--- a/kotori/io/protocol/util.py
+++ b/kotori/io/protocol/util.py
@@ -7,7 +7,7 @@ import arrow
 
 from arrow.parser import DateTimeParser
 from six import text_type
-from dateutil.tz import gettz
+from dateutil.tz import gettz, tzutc
 from dateutil.parser import parse
 from pyramid.settings import asbool
 from twisted.web import http
@@ -200,23 +200,27 @@ def slugify_datettime(dstring):
     return arrow.get(dstring).to('utc').format('YYYYMMDDTHHmmss')
 
 
-def parse_timestamp(timestamp):
+def parse_timestamp(timestamp, use_utc=False):
 
     if isinstance(timestamp, text_type):
 
         # FIXME: Maybe use system timezone here by default.
         # TODO: Make configurable via channel settings.
 
-        # HACK: Assume CET (Europe/Berlin) for human readable timestamp w/o timezone offset
+        # Handle naive human-readable timestamps w/o timezone offset.
         qualified = any([token in timestamp for token in ['Z', '+', ' CET', ' CEST']])
         if not qualified:
-            timestamp += ' CET'
+            # Assume CET (Europe/Berlin) (default), or UTC.
+            if use_utc:
+                timestamp += ' UTC'
+            else:
+                timestamp += ' CET'
 
         # Parse datetime string
         # Remark: Maybe use pandas.tseries.tools.parse_time_string?
         # TODO: Cache results of call to gettz to improve performance
         berlin = gettz('Europe/Berlin')
-        tzinfos = {'CET': berlin, 'CEST': berlin}
+        tzinfos = {'UTC': tzutc(), 'CET': berlin, 'CEST': berlin}
         timestamp = parse(timestamp, tzinfos=tzinfos)
 
     return timestamp

--- a/test/test_ecowitt.py
+++ b/test/test_ecowitt.py
@@ -1,4 +1,6 @@
 import json
+
+from kotori.io.protocol.util import parse_timestamp
 from test.settings.mqttkit import PROCESS_DELAY_HTTP, influx_sensors, settings
 from test.util import http_form_sensor, sleep
 
@@ -84,5 +86,8 @@ def test_ecowitt_post(machinery, create_influxdb, reset_influxdb):
 
     # Make sure this will not be public.
     assert "PASSKEY" not in record
+
+    # Make sure decoding the timestamp works.
+    assert parse_timestamp(record["time"]) == parse_timestamp("2023-02-20 16:02:19", use_utc=True)
 
     yield record


### PR DESCRIPTION
### About

We would like to get rid of the current default of assuming `CET` for all naive timestamps at data acquisition time, and use `UTC` instead.

> Date and time objects may be categorized as “aware” or “naive” depending on whether or not they include timezone information.
>
> With sufficient knowledge of applicable algorithmic and political time adjustments, such as time zone and daylight saving time information, an aware object can locate itself relative to other aware objects. An **aware** object represents a specific moment in time that is not open to interpretation. [^1]
>
> A **naive** object does not contain enough information to unambiguously locate itself relative to other date/time objects. Whether a naive object represents Coordinated Universal Time (UTC), local time, or time in some other timezone is purely up to the program, just like it is up to the program whether a particular number represents metres, miles, or mass. Naive objects are easy to understand and to work with, at the cost of ignoring some aspects of reality.
>
> -- [Python documentation » Basic date and time types » Aware and Naive Objects]

### Details
The current implementation is:

https://github.com/daq-tools/kotori/blob/de224af80719a6ba2ad0e6c1d5dca2ccd722ff2b/kotori/io/protocol/util.py#L180-L199

### Status
The patch is currently still a very early draft.

### Backlog

- FIXME: Maybe use system timezone by default.
- TODO: Make timezone configurable **per channel**.

[Python documentation » Basic date and time types » Aware and Naive Objects]: https://docs.python.org/3/library/datetime.html#aware-and-naive-objects

### SIG
/cc @tonkenfo, @einsiedlerkrebs, @msweef, @ClemensGruber, @wetterfrosch, @rohlan, @elektra42

[^1]: If, that is, we ignore the effects of Relativity.
