### PR TITLE
Grafana: Only permit numeric fields to be established on Graph panels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ in progress
 ===========
 
 - CI: Update to Grafana 9.3.0
+- Grafana: Only permit numeric fields to be established on Graph panels.
+  Other types will make the panel croak like ``InfluxDB Error: unsupported
+  mean iterator type: *query.stringInterruptIterator`` or ``InfluxDB Error:
+  not executed``.
 
 
 .. _kotori-0.27.0:

--- a/kotori/daq/graphing/grafana/dashboard.py
+++ b/kotori/daq/graphing/grafana/dashboard.py
@@ -57,7 +57,7 @@ class GrafanaDashboardBuilder(object):
 
         # Generate panels
         panels_new = self.panel_generator(data=data)
-        #print 'panels_new:'; pprint(panels_new)
+        # from pprint import pprint; print("panels_new:"); pprint(panels_new)
 
         # Create whole dashboard with all panels
         if not dashboard.dashboard_data:
@@ -268,7 +268,13 @@ class GrafanaDashboardBuilder(object):
         Field name collection helper.
         Does a prefix search over all fields in "data" and builds
         a list of field names like temp1, temp2, etc. in sorted order.
+
+        Only uses numeric fields and skips all others, because Grafana does not like them.
         """
+
+        def use_field(field_name: str):
+            value = data.get(field_name)
+            return isinstance(value, (float, int))
 
         # Filter blacklist fields
         # _hex_ is from intercom.c
@@ -280,12 +286,12 @@ class GrafanaDashboardBuilder(object):
             if field in blacklist:
                 continue
 
-            if prefixes is None:
+            if prefixes is None and use_field(field):
                 fields.append(field)
 
             elif isinstance(prefixes, list):
                 for prefix in prefixes:
-                    if field.startswith(prefix) or field.endswith(prefix):
+                    if (field.startswith(prefix) or field.endswith(prefix)) and use_field(field):
                         fields.append(field)
                         break
 


### PR DESCRIPTION
Hi again,

when testing GH-125 in production, we discovered at [^1] that Grafana would croak on non-numeric fields being established on the Graph panel. They will make the panel croak like `InfluxDB Error: unsupported mean iterator type: *query.stringInterruptIterator` or `InfluxDB Error: not executed` [^2].

![image](https://user-images.githubusercontent.com/453543/222296651-74c37654-cb06-4e37-bdf0-85c212abd543.png) ![image](https://user-images.githubusercontent.com/453543/222296696-03985855-4805-4fc4-8cd9-a421ad2fe470.png)

While the `ecowitt2mqtt` decoder strips all text fields like `PASSKEY`, `stationtype`, and `model` from the _original data_, it adds a few other text fields through its _computed data_:
```json
{
  "batt1": "OFF",
  "wh65batt": "OFF",
  "wh25batt": "OFF",
  "frostrisk": "No risk",
  "humidex_perception": "Comfortable",
  "thermalperception": "Dry"
}
```

This patch fixes it, by skipping all non-numeric fields when provisioning the Grafana panel.

With kind regards,
Andreas.

[^1]: https://climart.hiveeyes.org/grafana/d/climart-testdrive/climart-testdrive
[^2]: Did anyone of you observe this flaw in the past already, @tonkenfo, @wetterfrosch, or @ClemensGruber?
