### PR TITLE
[TTN] extract metadata from full TTN payload

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,11 +11,11 @@ in progress
   Other types will make the panel croak like ``InfluxDB Error: unsupported
   mean iterator type: *query.stringInterruptIterator`` or ``InfluxDB Error:
   not executed``.
-- Add TTS (The Things Stack) / TTN (The Things Network) decoder.
-  Thanks, @thiasB and @u-l-m-i.
 - Documentation: Modernize documentation and migrate to Read the Docs
   https://kotori.readthedocs.io/
-
+- [TTN] Add TTS (The Things Stack) / TTN (The Things Network) decoder.
+  Thanks, @thiasB and @u-l-m-i.
+- [TTN] Decode metadata from full TTN payload. Thanks, @thiasB.
 
 .. _kotori-0.27.0:
 

--- a/doc/source/handbook/decoders/tts-ttn.rst
+++ b/doc/source/handbook/decoders/tts-ttn.rst
@@ -54,6 +54,12 @@ Please configure the following settings:
 - ``Enabled event types``: For the event type ``Uplink message``, add the URL
   path suffix ``/data``.
 
+.. important::
+
+    If you want to receive the full TTN message payload, in order to decode additional
+    metadata, for example gateway information, please leave the ``Filter event data``
+    field empty.
+
 Example
 -------
 
@@ -66,28 +72,38 @@ This would be a corresponding set of example default values::
     Enabled event types:    /data
 
 
-*******
-Example
-*******
+********
+Examples
+********
 
-Now, JSON data payloads submitted from the TTN infrastructure to your system, like this
-example, will be decoded by Kotori transparently.
+Now, JSON data payloads submitted from the TTN infrastructure to your system, like those
+examples, will be decoded by Kotori transparently.
 
 .. literalinclude:: tts-ttn-uplink.json
     :language: json
 
-.. todo::
+Acquire and submit a minimal TTN JSON payload to Kotori's HTTP API.
 
-    Provide an example how a corresponding message can be submitted to TTN
-    from the terminal, in order to emulate the real scenario, but demonstrate
-    the telemetry data acquisition works well, almost end-to-end. In the meanwhile,
-    submit an example JSON message payload to Kotori's HTTP API directly::
+.. code-block:: shell
 
-        http https://github.com/daq-tools/kotori/raw/main/doc/source/handbook/decoders/tts-ttn-uplink.json \
-            | http POST https://daq.example.org/api/mqttkit-1/testdrive/area-42/node-1/data
+    wget https://github.com/daq-tools/kotori/raw/main/test/test_tts_ttn_minimal.json
+    cat test_tts_ttn_minimal.json | http POST https://daq.example.org/api/mqttkit-1/testdrive/area-42/node-minimal/data
+
+Acquire and submit a full TTN JSON payload to Kotori's HTTP API.
+
+.. code-block:: shell
+
+    wget https://github.com/daq-tools/kotori/raw/main/test/test_tts_ttn_full.json
+    cat test_tts_ttn_full.json | http POST https://daq.example.org/api/mqttkit-1/testdrive/area-42/node-full/data
+
+.. tip::
+
+    For submitting JSON data to the HTTP endpoint of Kotori, the authors recommend the
+    excellent `HTTPie`_ program. However, the same can also be achieved by using ``curl``.
 
 
 .. _configure an outbound Webhook: https://www.thethingsindustries.com/docs/integrations/webhooks/
+.. _HTTPie: https://httpie.io/
 .. _The Things Stack (TTS): https://www.thethingsindustries.com/docs/
 .. _The Things Network (TTN): https://www.thethingsnetwork.org/
 .. _The Things Network Console: https://www.thethingsnetwork.org/docs/network/console/

--- a/kotori/daq/decoder/tts_ttn.py
+++ b/kotori/daq/decoder/tts_ttn.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
-# (c) 2022 Andreas Motl <andreas@getkotori.org>
+# (c) 2019-2023 Andreas Motl <andreas@getkotori.org>
+# (c) 2019-2023 Matthias Büchner <m.buechner@gmail.com>
 import json
 from collections import OrderedDict
+import typing as t
+
+
+MessageValueType = t.Dict[str, t.Union[str, int, float, t.Dict[str, t.Any], t.List[t.Dict]]]
 
 
 class TheThingsStackDecoder:
@@ -17,25 +22,74 @@ class TheThingsStackDecoder:
     ==========
     - https://www.thethingsindustries.com/docs/the-things-stack/concepts/data-formats/#uplink-messages
     - https://www.thethingsindustries.com/docs/integrations/webhooks/
+    - https://www.thethingsnetwork.org/docs/lorawan/architecture/
+    - https://www.thethingsnetwork.org/docs/lorawan/message-types/
     - https://community.hiveeyes.org/t/more-data-acquisition-payload-formats-for-kotori/1421
     - https://community.hiveeyes.org/t/tts-ttn-daten-an-kotori-weiterleiten/1422/34
     """
 
-    @staticmethod
-    def decode(payload: str):
+    @classmethod
+    def decode(cls, payload: str):
 
         # Decode from JSON.
         message = json.loads(payload)
 
-        # Use timestamp and decoded payload.
         data = OrderedDict()
+
+        # Decode device id, timestamp, and decoded uplink message payload.
+        if "end_device_ids" in message:
+            data["device_id"] = message["end_device_ids"]["device_id"]
         if "received_at" in message:
             data["timestamp"] = message["received_at"]
-        data.update(message["uplink_message"]["decoded_payload"])
 
-        # TODO: Add more data / metadata.
-        #       This is an implementation from scratch. It can be improved by
-        #       cherry-picking more specific decoding routines from `ttnlogger`.
-        #       https://github.com/mqtt-tools/ttnlogger
+        if "uplink_message" in message:
+            data.update(cls.decode_uplink_message(message["uplink_message"]))
 
         return data
+
+    @classmethod
+    def decode_uplink_message(cls, uplink_message: MessageValueType):
+        """
+        Decode a TTN uplink message, i.e. originating from the appliance/device.
+        """
+
+        data = OrderedDict()
+
+        # Decode message payload.
+        data.update(uplink_message["decoded_payload"])
+
+        # Extract infrastructure data.
+        if "settings" in uplink_message:
+            data["bw"] = uplink_message["settings"]["data_rate"]["lora"]["bandwidth"] / 1000
+            data["sf"] = uplink_message["settings"]["data_rate"]["lora"]["spreading_factor"]
+            data["freq"] = float(uplink_message["settings"]["frequency"]) / 1000000.0
+        if "f_cnt" in uplink_message:
+            data["counter"] = int(uplink_message["f_cnt"])
+        if "rx_metadata" in uplink_message:
+            data["gtw_count"] = len(uplink_message["rx_metadata"])
+            for rx_metadata in uplink_message["rx_metadata"]:
+                gateway_id = rx_metadata["gateway_ids"]["gateway_id"]
+                data["gw_" + gateway_id + "_rssi"] = rx_metadata["rssi"]
+                data["gw_" + gateway_id + "_snr"] = rx_metadata["snr"]
+
+        return data
+
+
+if __name__ == "__main__":
+    """
+    About
+    =====
+    Decode a TTN JSON payload file on the command line.
+
+    Synopsis
+    ========
+    ::
+
+        python -m kotori.daq.decoder.tts_ttn "test/test_tts_ttn_full.json"
+        python -m kotori.daq.decoder.tts_ttn "test/test_tts_ttn_minimal.json"
+    """
+    import sys
+
+    filepath = sys.argv[1]
+    data = TheThingsStackDecoder.decode(open(filepath).read())
+    print(json.dumps(data, indent=2))

--- a/test/test_tts_ttn_full.json
+++ b/test/test_tts_ttn_full.json
@@ -1,6 +1,6 @@
 {
   "end_device_ids": {
-    "device_id": "testdrive-foo-bar-baz",
+    "device_id": "foo-bar-baz",
     "application_ids": {
       "application_id": "acme"
     },

--- a/test/util.py
+++ b/test/util.py
@@ -278,7 +278,14 @@ def idgen(size=6, chars=string.ascii_uppercase + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
 
 
+def read_file(name: str) -> bytes:
+    path = os.path.join(os.path.dirname(__file__), name)
+    with open(path, mode="rb") as f:
+        return f.read()
+
+
 def read_jsonfile(name: str) -> t.Dict[str, t.Any]:
+    return json.loads(read_file(name))
     path = os.path.join(os.path.dirname(__file__), name)
     with open(path, mode="r") as f:
         return json.load(f)


### PR DESCRIPTION
Building upon GH-81, this improves the TTN decoder a bit. The keys have been named like how they are already defined in our [TTN->Hiveeyes PutsReq converter](https://github.com/hiveeyes/terkin-datalogger/blob/main/client/TTN/putsreq.hiveeyes.ttn_v3.js).

/cc @ClemensGruber, @MKO1640
