### PR TITLE
[DA] Add per-device addressing (DA) to WAN topic/channel decoding strategy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,9 +16,11 @@ in progress
 - [TTN] Add TTS (The Things Stack) / TTN (The Things Network) decoder.
   Thanks, @thiasB and @u-l-m-i.
 - [TTN] Decode metadata from full TTN payload. Thanks, @thiasB.
-- [DA] Add per-device addressing and topic decoding strategies. Thanks, @thiasB.
-  ``mqttkit-1/d/123e4567-e89b-12d3-a456-426614174000``
-  ``mqttkit-1/dt/network-gateway-node``
+- [DA] Add per-device addressing and topic decoding strategies. Thanks,
+  @thiasB and @ClemensGruber. Examples:
+
+  - ``mqttkit-1/device/123e4567-e89b-12d3-a456-426614174000``
+  - ``mqttkit-1/channel/network-gateway-node``
 
 
 .. _kotori-0.27.0:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ in progress
 - [TTN] Add TTS (The Things Stack) / TTN (The Things Network) decoder.
   Thanks, @thiasB and @u-l-m-i.
 - [TTN] Decode metadata from full TTN payload. Thanks, @thiasB.
+- [DA] Add per-device addressing and topic decoding strategies. Thanks, @thiasB.
+  ``mqttkit-1/d/123e4567-e89b-12d3-a456-426614174000``
+  ``mqttkit-1/dt/network-gateway-node``
+
 
 .. _kotori-0.27.0:
 

--- a/doc/source/handbook/configuration/mqttkit.rst
+++ b/doc/source/handbook/configuration/mqttkit.rst
@@ -51,13 +51,17 @@ attribute of the main application settings section.
 .. literalinclude:: ../../_static/content/etc/examples/mqttkit.ini
     :language: ini
     :linenos:
-    :lines: 10-27
-    :emphasize-lines: 4,11-18
+    :lines: 10-30
+    :emphasize-lines: 4,14-21
 
 
 **********
 Addressing
 **********
+
+Wide channel
+============
+
 To successfully publish data to the platform, you should get familiar with the MQTTKit addressing scheme.
 We call it the »quadruple hierarchy strategy« and it is reflected on the mqtt bus topic topology.
 
@@ -89,6 +93,36 @@ The topology identifiers are specified as:
 In the following examples, this topology address will be encoded into the variable ``CHANNEL``.
 
 
+Direct channel
+==============
+
+When using the :ref:`hiveeyes-arduino:sensorwan-direct-addressing` scheme of
+:ref:`hiveeyes-arduino:sensorwan`, it is possible to detour from the "wide" addressing scheme,
+and submit data "directly" to a channel address like ``mqttkit-1/channel/<network>-<gateway>-<node>``
+instead.
+
+In order to restrict access to that addressing flavour to specific networks/owners only,
+you can use the ``direct_channel_allowed_networks`` configuration setting, where you can
+enumerate network/owner path components, which are allowed to submit data on their
+corresponding channel groups.
+
+.. literalinclude:: ../../_static/content/etc/examples/mqttkit.ini
+    :language: ini
+    :linenos:
+    :lines: 20-21
+
+For all others, access will be rejected by raising an ``ChannelAccessDenied`` exception.
+
+
+Direct device
+=============
+
+The :ref:`hiveeyes-arduino:sensorwan-direct-addressing` scheme also allows you to address
+channels by device identifiers only, also detouring from the "wide" addressing scheme.
+
+| An example for a corresponding channel address, identifying devices by `UUID`_, would be
+| ``mqttkit-1/device/123e4567-e89b-12d3-a456-426614174000``.
+
 
 ************
 Sending data
@@ -105,6 +139,12 @@ will be encoded into the variable ``CHANNEL``.
     DATA='{"temperature": 42.84, "humidity": 83.1}'
 
     # Publish telemetry data to MQTT topic.
+    echo "$DATA" | mosquitto_pub -t $CHANNEL/data.json -l
+
+When using the "direct channel" addressing scheme, those invocations would address
+the same channel as in the previous example::
+
+    CHANNEL=mqttkit-1/channel/testdrive-foobar-42
     echo "$DATA" | mosquitto_pub -t $CHANNEL/data.json -l
 
 

--- a/etc/examples/mqttkit.ini
+++ b/etc/examples/mqttkit.ini
@@ -17,6 +17,9 @@ application = kotori.daq.application.mqttkit:mqttkit_application
 # How often to log metrics
 metrics_logger_interval = 60
 
+# Restrict SensorWAN direct addressing to specified networks/owners.
+direct_channel_allowed_networks = itest, testdrive
+
 # [mqttkit-1:mqtt]
 # ; Configure individual MQTT broker for this application.
 # ; The option group prefix `mqttkit-1` reflects the value of

--- a/kotori/daq/application/mqttkit.py
+++ b/kotori/daq/application/mqttkit.py
@@ -28,7 +28,7 @@ class MqttKitApplication(RootService):
         service = MqttInfluxGrafanaService(
             channel  = self.channel,
             # Data processing strategy and graphing components
-            strategy=WanBusStrategy(),
+            strategy=WanBusStrategy(channel_settings=self.channel),
             graphing=GrafanaManager(settings=global_settings, channel=self.channel)
             )
 

--- a/kotori/daq/strategy/__init__.py
+++ b/kotori/daq/strategy/__init__.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 # (c) 2015-2021 Andreas Motl, <andreas@getkotori.org>
+from munch import Munch
+
 from kotori.daq.decoder import MessageType
 
 
 class StrategyBase:
+
+    def __init__(self, channel_settings=None):
+        channel_settings = channel_settings or Munch()
+        self.channel_settings = channel_settings
 
     @staticmethod
     def sanitize_db_identifier(value):

--- a/kotori/vendor/hiveeyes/application.py
+++ b/kotori/vendor/hiveeyes/application.py
@@ -311,7 +311,7 @@ def hiveeyes_boot(settings, debug=False):
             HiveeyesGenericGrafanaManager(settings=settings, channel=channel),
             HiveeyesBeehiveGrafanaManager(settings=settings, channel=channel),
         ],
-        strategy = WanBusStrategy()
+        strategy = WanBusStrategy(channel_settings=channel)
     )
 
     rootService.registerService(service)

--- a/pytest.ini
+++ b/pytest.ini
@@ -43,3 +43,4 @@ markers =
     hiveeyes: Tests for vendor hiveeyes.
     legacy: Tests for legacy endpoints and such.
     device: Device-based addressing.
+    strategy: Transformation strategies.

--- a/pytest.ini
+++ b/pytest.ini
@@ -42,3 +42,4 @@ markers =
     ttn: Tests for TTS/TTN adapter.
     hiveeyes: Tests for vendor hiveeyes.
     legacy: Tests for legacy endpoints and such.
+    device: Device-based addressing.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,7 +11,7 @@ import pytest_twisted
 
 from kotori import KotoriBootloader
 from test.util import boot_kotori, sleep
-from test.settings.mqttkit import influx_sensors, influx_events, grafana
+from test.settings.mqttkit import influx_sensors, influx_events, grafana, device_influx_sensors
 
 logger = logging.getLogger(__name__)
 
@@ -52,5 +52,8 @@ create_influxdb = influx_sensors.make_create_db()
 reset_influxdb = influx_sensors.make_reset_measurement()
 reset_grafana = grafana.make_reset()
 reset_influxdb_events = influx_events.make_reset_measurement()
+
+device_create_influxdb = device_influx_sensors.make_create_db()
+device_reset_influxdb = device_influx_sensors.make_reset_measurement()
 
 machinery_basic = create_machinery('./etc/test/basic.ini')

--- a/test/settings/mqttkit.py
+++ b/test/settings/mqttkit.py
@@ -36,12 +36,12 @@ class TestSettings:
     channel_path_airrohr = '/mqttkit-1/itest/foo/bar/custom/airrohr'
 
     # Per-device entrypoints.
-    device_influx_database            = 'mqttkit_1_devices'
-    device_influx_measurement_sensors = 'default_123e4567_e89b_12d3_a456_426614174000_sensors'
-    device_mqtt_topic_generic      = 'mqttkit-1/d/123e4567-e89b-12d3-a456-426614174000/data.json'
-    device_mqtt_topic_dashed_topo  = 'mqttkit-1/dt/itest-foo-bar/data.json'
-    device_http_path_generic       = '/mqttkit-1/d/123e4567-e89b-12d3-a456-426614174000/data'
-    device_http_path_dashed_topo   = '/mqttkit-1/dt/itest-foo-bar/data'
+    direct_influx_database            = 'mqttkit_1_devices'
+    direct_influx_measurement_sensors = 'default_123e4567_e89b_12d3_a456_426614174000_sensors'
+    direct_mqtt_topic_device          = 'mqttkit-1/device/123e4567-e89b-12d3-a456-426614174000/data.json'
+    direct_mqtt_topic_channel         = 'mqttkit-1/channel/itest-foo-bar/data.json'
+    direct_http_path_device           = '/mqttkit-1/device/123e4567-e89b-12d3-a456-426614174000/data'
+    direct_http_path_channel          = '/mqttkit-1/channel/itest-foo-bar/data'
 
 
 settings = TestSettings
@@ -50,4 +50,4 @@ influx_sensors = InfluxWrapper(database=settings.influx_database, measurement=se
 influx_events = InfluxWrapper(database=settings.influx_database, measurement=settings.influx_measurement_events)
 grafana = GrafanaWrapper(settings=settings)
 
-device_influx_sensors = InfluxWrapper(database=settings.device_influx_database, measurement=settings.device_influx_measurement_sensors)
+device_influx_sensors = InfluxWrapper(database=settings.direct_influx_database, measurement=settings.direct_influx_measurement_sensors)

--- a/test/settings/mqttkit.py
+++ b/test/settings/mqttkit.py
@@ -40,6 +40,8 @@ class TestSettings:
     device_influx_measurement_sensors = 'default_123e4567_e89b_12d3_a456_426614174000_sensors'
     device_mqtt_topic_generic      = 'mqttkit-1/d/123e4567-e89b-12d3-a456-426614174000/data.json'
     device_mqtt_topic_dashed_topo  = 'mqttkit-1/dt/itest-foo-bar/data.json'
+    device_http_path_generic       = '/mqttkit-1/d/123e4567-e89b-12d3-a456-426614174000/data'
+    device_http_path_dashed_topo   = '/mqttkit-1/dt/itest-foo-bar/data'
 
 
 settings = TestSettings

--- a/test/settings/mqttkit.py
+++ b/test/settings/mqttkit.py
@@ -35,9 +35,17 @@ class TestSettings:
     channel_path_event   = '/mqttkit-1/itest/foo/bar/event'
     channel_path_airrohr = '/mqttkit-1/itest/foo/bar/custom/airrohr'
 
+    # Per-device entrypoints.
+    device_influx_database            = 'mqttkit_1_devices'
+    device_influx_measurement_sensors = 'default_123e4567_e89b_12d3_a456_426614174000_sensors'
+    device_mqtt_topic_generic      = 'mqttkit-1/d/123e4567-e89b-12d3-a456-426614174000/data.json'
+    device_mqtt_topic_dashed_topo  = 'mqttkit-1/dt/itest-foo-bar/data.json'
+
 
 settings = TestSettings
 
 influx_sensors = InfluxWrapper(database=settings.influx_database, measurement=settings.influx_measurement_sensors)
 influx_events = InfluxWrapper(database=settings.influx_database, measurement=settings.influx_measurement_events)
 grafana = GrafanaWrapper(settings=settings)
+
+device_influx_sensors = InfluxWrapper(database=settings.device_influx_database, measurement=settings.device_influx_measurement_sensors)

--- a/test/settings/mqttkit.py
+++ b/test/settings/mqttkit.py
@@ -40,6 +40,7 @@ class TestSettings:
     direct_influx_measurement_sensors = 'default_123e4567_e89b_12d3_a456_426614174000_sensors'
     direct_mqtt_topic_device          = 'mqttkit-1/device/123e4567-e89b-12d3-a456-426614174000/data.json'
     direct_mqtt_topic_channel         = 'mqttkit-1/channel/itest-foo-bar/data.json'
+    direct_mqtt_topic_channel_denied  = 'mqttkit-1/channel/another-foo-bar/data.json'
     direct_http_path_device           = '/mqttkit-1/device/123e4567-e89b-12d3-a456-426614174000/data'
     direct_http_path_channel          = '/mqttkit-1/channel/itest-foo-bar/data'
 

--- a/test/test_daq_http.py
+++ b/test/test_daq_http.py
@@ -48,12 +48,12 @@ def test_http_json_valid(machinery, create_influxdb, reset_influxdb):
 @pytest_twisted.inlineCallbacks
 @pytest.mark.http
 @pytest.mark.device
-def test_http_json_wan_device_generic(machinery, device_create_influxdb, device_reset_influxdb):
+def test_http_json_wan_device(machinery, device_create_influxdb, device_reset_influxdb):
     """
     Run HTTP data acquisition with per-device addressing.
 
-    Addressing: Per-device WAN
-    Example:    mqttkit-1/d/123e4567-e89b-12d3-a456-426614174000
+    Addressing: SensorWAN direct-device
+    Example:    mqttkit-1/device/123e4567-e89b-12d3-a456-426614174000
     """
 
     # Submit a single measurement, without timestamp.
@@ -61,7 +61,7 @@ def test_http_json_wan_device_generic(machinery, device_create_influxdb, device_
         'temperature': 25.26,
         'humidity': 51.8,
     }
-    deferred = threads.deferToThread(http_json_sensor, settings.device_http_path_generic, data)
+    deferred = threads.deferToThread(http_json_sensor, settings.direct_http_path_device, data)
     yield deferred
 
     # Check response.
@@ -82,12 +82,12 @@ def test_http_json_wan_device_generic(machinery, device_create_influxdb, device_
 @pytest_twisted.inlineCallbacks
 @pytest.mark.http
 @pytest.mark.device
-def test_http_json_wan_device_dashed(machinery, create_influxdb, reset_influxdb):
+def test_http_json_wan_channel(machinery, create_influxdb, reset_influxdb):
     """
     Run MQTT data acquisition with per-device dashed-topo addressing.
 
-    Addressing: Per-device WAN, with dashed topology decoding
-    Example:    mqttkit-1/dt/network-gateway-node
+    Addressing: SensorWAN direct-channel, with dashed topology decoding
+    Example:    mqttkit-1/channel/network-gateway-node
     """
 
     # Submit a single measurement, without timestamp.
@@ -95,7 +95,7 @@ def test_http_json_wan_device_dashed(machinery, create_influxdb, reset_influxdb)
         'temperature': 25.26,
         'humidity': 51.8,
     }
-    deferred = threads.deferToThread(http_json_sensor, settings.device_http_path_dashed_topo, data)
+    deferred = threads.deferToThread(http_json_sensor, settings.direct_http_path_channel, data)
     yield deferred
 
     # Check response.

--- a/test/test_daq_mqtt.py
+++ b/test/test_daq_mqtt.py
@@ -95,12 +95,12 @@ def test_mqtt_to_influxdb_discrete(machinery, create_influxdb, reset_influxdb):
 @pytest_twisted.inlineCallbacks
 @pytest.mark.mqtt
 @pytest.mark.device
-def test_mqtt_to_influxdb_json_wan_device_generic(machinery, device_create_influxdb, device_reset_influxdb):
+def test_mqtt_to_influxdb_json_wan_device(machinery, device_create_influxdb, device_reset_influxdb):
     """
     Run MQTT data acquisition with per-device addressing.
 
-    Addressing: Per-device WAN
-    Example:    mqttkit-1/d/123e4567-e89b-12d3-a456-426614174000
+    Addressing: SensorWAN direct-device
+    Example:    mqttkit-1/device/123e4567-e89b-12d3-a456-426614174000
     """
 
     # Submit a single measurement, without timestamp.
@@ -108,7 +108,7 @@ def test_mqtt_to_influxdb_json_wan_device_generic(machinery, device_create_influ
         'temperature': 42.84,
         'humidity': 83.1,
     }
-    yield threads.deferToThread(mqtt_json_sensor, settings.device_mqtt_topic_generic, data)
+    yield threads.deferToThread(mqtt_json_sensor, settings.direct_mqtt_topic_device, data)
 
     # Wait for some time to process the message.
     yield sleep(PROCESS_DELAY_MQTT)
@@ -123,12 +123,12 @@ def test_mqtt_to_influxdb_json_wan_device_generic(machinery, device_create_influ
 @pytest_twisted.inlineCallbacks
 @pytest.mark.mqtt
 @pytest.mark.device
-def test_mqtt_to_influxdb_json_wan_device_dashed(machinery, create_influxdb, reset_influxdb):
+def test_mqtt_to_influxdb_json_wan_channel(machinery, create_influxdb, reset_influxdb):
     """
     Run MQTT data acquisition with per-device dashed-topo addressing.
 
     Addressing: Per-device WAN, with dashed topology decoding
-    Example:    mqttkit-1/dt/network-gateway-node
+    Example:    mqttkit-1/channel/network-gateway-node
     """
 
     # Submit a single measurement, without timestamp.
@@ -136,7 +136,7 @@ def test_mqtt_to_influxdb_json_wan_device_dashed(machinery, create_influxdb, res
         'temperature': 42.84,
         'humidity': 83.1,
     }
-    yield threads.deferToThread(mqtt_json_sensor, settings.device_mqtt_topic_dashed_topo, data)
+    yield threads.deferToThread(mqtt_json_sensor, settings.direct_mqtt_topic_channel, data)
 
     # Wait for some time to process the message.
     yield sleep(PROCESS_DELAY_MQTT)

--- a/test/test_daq_mqtt.py
+++ b/test/test_daq_mqtt.py
@@ -6,7 +6,7 @@ import pytest
 import pytest_twisted
 from twisted.internet import threads
 
-from test.settings.mqttkit import settings, influx_sensors, PROCESS_DELAY_MQTT
+from test.settings.mqttkit import settings, influx_sensors, PROCESS_DELAY_MQTT, device_influx_sensors
 from test.util import mqtt_json_sensor, sleep, mqtt_sensor
 
 logger = logging.getLogger(__name__)
@@ -18,6 +18,9 @@ def test_mqtt_to_influxdb_json_single(machinery, create_influxdb, reset_influxdb
     """
     Publish single reading in JSON format to MQTT broker
     and proof it is stored in the InfluxDB database.
+
+    Addressing: Classic WAN path
+    Example:    mqttkit-1/network/gateway/node
     """
 
     # Submit a single measurement, without timestamp.
@@ -44,6 +47,9 @@ def test_mqtt_to_influxdb_json_legacy_topic(machinery, create_influxdb, reset_in
     """
     Publish single reading in JSON format to MQTT broker on legacy suffix
     and proof it is stored in the InfluxDB database.
+
+    Addressing: Classic WAN path
+    Example:    mqttkit-1/network/gateway/node
     """
 
     # Submit a single measurement, without timestamp.
@@ -67,6 +73,9 @@ def test_mqtt_to_influxdb_discrete(machinery, create_influxdb, reset_influxdb):
     """
     Publish discrete values to the MQTT broker
     and proof they are stored in the InfluxDB database.
+
+    Addressing: Classic WAN path + discrete
+    Example:    mqttkit-1/network/gateway/node/data/field
     """
 
     # Submit discrete measurement values, without timestamp.
@@ -81,3 +90,59 @@ def test_mqtt_to_influxdb_discrete(machinery, create_influxdb, reset_influxdb):
     # Proof that data arrived in InfluxDB.
     record = influx_sensors.get_first_record()
     assert 'temperature' in record or 'humidity' in record
+
+
+@pytest_twisted.inlineCallbacks
+@pytest.mark.mqtt
+@pytest.mark.device
+def test_mqtt_to_influxdb_json_wan_device_generic(machinery, device_create_influxdb, device_reset_influxdb):
+    """
+    Run MQTT data acquisition with per-device addressing.
+
+    Addressing: Per-device WAN
+    Example:    mqttkit-1/d/123e4567-e89b-12d3-a456-426614174000
+    """
+
+    # Submit a single measurement, without timestamp.
+    data = {
+        'temperature': 42.84,
+        'humidity': 83.1,
+    }
+    yield threads.deferToThread(mqtt_json_sensor, settings.device_mqtt_topic_generic, data)
+
+    # Wait for some time to process the message.
+    yield sleep(PROCESS_DELAY_MQTT)
+
+    # Proof that data arrived in InfluxDB.
+    record = device_influx_sensors.get_first_record()
+    del record['time']
+    assert record == {u'humidity': 83.1, u'temperature': 42.84}
+    yield record
+
+
+@pytest_twisted.inlineCallbacks
+@pytest.mark.mqtt
+@pytest.mark.device
+def test_mqtt_to_influxdb_json_wan_device_dashed(machinery, create_influxdb, reset_influxdb):
+    """
+    Run MQTT data acquisition with per-device dashed-topo addressing.
+
+    Addressing: Per-device WAN, with dashed topology decoding
+    Example:    mqttkit-1/dt/network-gateway-node
+    """
+
+    # Submit a single measurement, without timestamp.
+    data = {
+        'temperature': 42.84,
+        'humidity': 83.1,
+    }
+    yield threads.deferToThread(mqtt_json_sensor, settings.device_mqtt_topic_dashed_topo, data)
+
+    # Wait for some time to process the message.
+    yield sleep(PROCESS_DELAY_MQTT)
+
+    # Proof that data arrived in InfluxDB.
+    record = influx_sensors.get_first_record()
+    del record['time']
+    assert record == {u'humidity': 83.1, u'temperature': 42.84}
+    yield record

--- a/test/test_wan_strategy.py
+++ b/test/test_wan_strategy.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # (c) 2023 Andreas Motl <andreas@getkotori.org>
 import pytest
+from munch import munchify
 
+from kotori.daq.exception import ChannelAccessDenied
 from kotori.daq.strategy.wan import WanBusStrategy
 from kotori.util.common import SmartMunch
 
@@ -43,7 +45,7 @@ def test_wan_strategy_device_generic_success():
 
 
 @pytest.mark.strategy
-def test_wan_strategy_device_dashed_topo_basic():
+def test_wan_strategy_device_dashed_topo_basic_success():
     """
     Verify the per-device WAN topology decoding, using a dashed device identifier, which translates to the topology.
     """
@@ -58,6 +60,17 @@ def test_wan_strategy_device_dashed_topo_basic():
             "slot": "data.json",
         }
     )
+
+
+@pytest.mark.strategy
+def test_wan_strategy_device_dashed_topo_basic_access_denied():
+    """
+    Verify the per-device WAN topology decoding, using a dashed device identifier, which translates to the topology.
+    """
+    strategy = WanBusStrategy(channel_settings=munchify({"direct_channel_allowed_networks": "foo, bar"}))
+    with pytest.raises(ChannelAccessDenied) as ex:
+        strategy.topic_to_topology("myrealm/channel/baz-qux-eui70b3d57ed005dac6/data.json")
+    assert ex.match("Rejected access to SensorWAN network: baz")
 
 
 @pytest.mark.strategy

--- a/test/test_wan_strategy.py
+++ b/test/test_wan_strategy.py
@@ -7,7 +7,7 @@ from kotori.util.common import SmartMunch
 
 
 @pytest.mark.strategy
-def test_wan_strategy_channel():
+def test_wan_strategy_wide_channel():
     """
     Verify the classic WAN topology decoding, using a channel-based addressing scheme.
     """
@@ -30,7 +30,7 @@ def test_wan_strategy_device_generic_success():
     Verify the per-device WAN topology decoding, using a generic device identifier.
     """
     strategy = WanBusStrategy()
-    topology = strategy.topic_to_topology("myrealm/d/123e4567-e89b-12d3-a456-426614174000/data.json")
+    topology = strategy.topic_to_topology("myrealm/device/123e4567-e89b-12d3-a456-426614174000/data.json")
     assert topology == SmartMunch(
         {
             "realm": "myrealm",
@@ -48,7 +48,7 @@ def test_wan_strategy_device_dashed_topo_basic():
     Verify the per-device WAN topology decoding, using a dashed device identifier, which translates to the topology.
     """
     strategy = WanBusStrategy()
-    topology = strategy.topic_to_topology("myrealm/dt/acme-area42-eui70b3d57ed005dac6/data.json")
+    topology = strategy.topic_to_topology("myrealm/channel/acme-area42-eui70b3d57ed005dac6/data.json")
     assert topology == SmartMunch(
         {
             "realm": "myrealm",
@@ -69,7 +69,7 @@ def test_wan_strategy_device_dashed_topo_too_few_components():
     This specific test uses a vanilla TTN device identifier.
     """
     strategy = WanBusStrategy()
-    topology = strategy.topic_to_topology("myrealm/dt/eui-70b3d57ed005dac6/data.json")
+    topology = strategy.topic_to_topology("myrealm/channel/eui-70b3d57ed005dac6/data.json")
     assert topology == SmartMunch(
         {
             "realm": "myrealm",
@@ -88,7 +88,7 @@ def test_wan_strategy_device_dashed_topo_three_components():
     This topic will be decoded as-is.
     """
     strategy = WanBusStrategy()
-    topology = strategy.topic_to_topology("myrealm/dt/acme-area42-eui70b3d57ed005dac6/data.json")
+    topology = strategy.topic_to_topology("myrealm/channel/acme-area42-eui70b3d57ed005dac6/data.json")
     assert topology == SmartMunch(
         {
             "realm": "myrealm",
@@ -107,7 +107,7 @@ def test_wan_strategy_device_dashed_topo_too_many_components_merge_suffixes():
     The solution is to merge all trailing segments into the `node` slot, re-joining them with `-`.
     """
     strategy = WanBusStrategy()
-    topology = strategy.topic_to_topology("myrealm/dt/acme-area42-eui70b3d57ed005dac6-suffix/data.json")
+    topology = strategy.topic_to_topology("myrealm/channel/acme-area42-eui70b3d57ed005dac6-suffix/data.json")
     assert topology == SmartMunch(
         {
             "realm": "myrealm",
@@ -132,7 +132,7 @@ def test_wan_strategy_device_dashed_topo_too_many_components_redundant_realm():
     Cheers, @thiasB.
     """
     strategy = WanBusStrategy()
-    topology = strategy.topic_to_topology("myrealm/dt/myrealm-acme-area42-eui70b3d57ed005dac6/data.json")
+    topology = strategy.topic_to_topology("myrealm/channel/myrealm-acme-area42-eui70b3d57ed005dac6/data.json")
     assert topology == SmartMunch(
         {
             "realm": "myrealm",
@@ -151,7 +151,7 @@ def test_wan_strategy_device_generic_empty():
     Topic-to-topology decoding should return `None`.
     """
     strategy = WanBusStrategy()
-    topology = strategy.topic_to_topology("myrealm/d/data.json")
+    topology = strategy.topic_to_topology("myrealm/device/data.json")
     assert topology is None
 
 
@@ -162,5 +162,5 @@ def test_wan_strategy_device_dashed_topo_empty():
     Topic-to-topology decoding should return `None`.
     """
     strategy = WanBusStrategy()
-    topology = strategy.topic_to_topology("myrealm/dt/data.json")
+    topology = strategy.topic_to_topology("myrealm/channel/data.json")
     assert topology is None

--- a/test/test_wan_strategy.py
+++ b/test/test_wan_strategy.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+# (c) 2023 Andreas Motl <andreas@getkotori.org>
+import pytest
+
+from kotori.daq.strategy.wan import WanBusStrategy
+from kotori.util.common import SmartMunch
+
+
+@pytest.mark.strategy
+def test_wan_strategy_channel():
+    """
+    Verify the classic WAN topology decoding, using a channel-based addressing scheme.
+    """
+    strategy = WanBusStrategy()
+    topology = strategy.topic_to_topology("myrealm/acme/area-42/foo-70b3d57ed005dac6/data.json")
+    assert topology == SmartMunch(
+        {
+            "realm": "myrealm",
+            "network": "acme",
+            "gateway": "area-42",
+            "node": "foo-70b3d57ed005dac6",
+            "slot": "data.json",
+        }
+    )
+
+
+@pytest.mark.strategy
+def test_wan_strategy_device_generic_success():
+    """
+    Verify the per-device WAN topology decoding, using a generic device identifier.
+    """
+    strategy = WanBusStrategy()
+    topology = strategy.topic_to_topology("myrealm/d/123e4567-e89b-12d3-a456-426614174000/data.json")
+    assert topology == SmartMunch(
+        {
+            "realm": "myrealm",
+            "network": "devices",
+            "gateway": "default",
+            "node": "123e4567-e89b-12d3-a456-426614174000",
+            "slot": "data.json",
+        }
+    )
+
+
+@pytest.mark.strategy
+def test_wan_strategy_device_dashed_topo_basic():
+    """
+    Verify the per-device WAN topology decoding, using a dashed device identifier, which translates to the topology.
+    """
+    strategy = WanBusStrategy()
+    topology = strategy.topic_to_topology("myrealm/dt/acme-area42-eui70b3d57ed005dac6/data.json")
+    assert topology == SmartMunch(
+        {
+            "realm": "myrealm",
+            "network": "acme",
+            "gateway": "area42",
+            "node": "eui70b3d57ed005dac6",
+            "slot": "data.json",
+        }
+    )
+
+
+@pytest.mark.strategy
+def test_wan_strategy_device_dashed_topo_too_few_components():
+    """
+    Verify the per-device WAN topology decoding, using a dashed device identifier with too few components.
+    The solution is to pad the segments with `default` labels at the front.
+
+    This specific test uses a vanilla TTN device identifier.
+    """
+    strategy = WanBusStrategy()
+    topology = strategy.topic_to_topology("myrealm/dt/eui-70b3d57ed005dac6/data.json")
+    assert topology == SmartMunch(
+        {
+            "realm": "myrealm",
+            "network": "default",
+            "gateway": "eui",
+            "node": "70b3d57ed005dac6",
+            "slot": "data.json",
+        }
+    )
+
+
+@pytest.mark.strategy
+def test_wan_strategy_device_dashed_topo_three_components():
+    """
+    Verify the per-device WAN topology decoding, using a dashed device identifier with exactly three components.
+    This topic will be decoded as-is.
+    """
+    strategy = WanBusStrategy()
+    topology = strategy.topic_to_topology("myrealm/dt/acme-area42-eui70b3d57ed005dac6/data.json")
+    assert topology == SmartMunch(
+        {
+            "realm": "myrealm",
+            "network": "acme",
+            "gateway": "area42",
+            "node": "eui70b3d57ed005dac6",
+            "slot": "data.json",
+        }
+    )
+
+
+@pytest.mark.strategy
+def test_wan_strategy_device_dashed_topo_too_many_components_merge_suffixes():
+    """
+    Verify the per-device WAN topology decoding, using a dashed device identifier with too many components.
+    The solution is to merge all trailing segments into the `node` slot, re-joining them with `-`.
+    """
+    strategy = WanBusStrategy()
+    topology = strategy.topic_to_topology("myrealm/dt/acme-area42-eui70b3d57ed005dac6-suffix/data.json")
+    assert topology == SmartMunch(
+        {
+            "realm": "myrealm",
+            "network": "acme",
+            "gateway": "area42",
+            "node": "eui70b3d57ed005dac6-suffix",
+            "slot": "data.json",
+        }
+    )
+
+
+@pytest.mark.strategy
+def test_wan_strategy_device_dashed_topo_too_many_components_redundant_realm():
+    """
+    Verify the per-device WAN topology decoding, using a dashed device identifier with too many components.
+
+    This is an edge case where the first addressing component actually equals the realm.
+    Strictly, it is a misconfiguration, but we pretend to be smart, and ignore that,
+    effectively not using the redundant information, and ignoring the `myrealm-` prefix
+    within the device identifier slot altogether.
+
+    Cheers, @thiasB.
+    """
+    strategy = WanBusStrategy()
+    topology = strategy.topic_to_topology("myrealm/dt/myrealm-acme-area42-eui70b3d57ed005dac6/data.json")
+    assert topology == SmartMunch(
+        {
+            "realm": "myrealm",
+            "network": "acme",
+            "gateway": "area42",
+            "node": "eui70b3d57ed005dac6",
+            "slot": "data.json",
+        }
+    )
+
+
+@pytest.mark.strategy
+def test_wan_strategy_device_generic_empty():
+    """
+    Verify the per-device WAN topology decoding, using a generic device identifier with no components.
+    Topic-to-topology decoding should return `None`.
+    """
+    strategy = WanBusStrategy()
+    topology = strategy.topic_to_topology("myrealm/d/data.json")
+    assert topology is None
+
+
+@pytest.mark.strategy
+def test_wan_strategy_device_dashed_topo_empty():
+    """
+    Verify the per-device WAN topology decoding, using a dashed device identifier with no components.
+    Topic-to-topology decoding should return `None`.
+    """
+    strategy = WanBusStrategy()
+    topology = strategy.topic_to_topology("myrealm/dt/data.json")
+    assert topology is None


### PR DESCRIPTION
## About
This patch implements the proposal outlined at GH-133, adding a generic per-device topic addressing scheme, not exclusively but also in order to bring in multi-tenant TTN support, see GH-8.

## Documentation
... is still missing. But reading the code, specifically the test cases and inline comments, will give you an idea.

## Details
- Per-device addressing and topic/channel decoding strategies. Valid examples are:
  ```
  # Addressing a device.
  mqttkit-1/device/123e4567-e89b-12d3-a456-426614174000

  # Addressing a channel.
  mqttkit-1/channel/network-gateway-node
  ```

## Backlog
- [x] Channel isolation / authentication, see https://github.com/daq-tools/kotori/issues/133#issuecomment-1562003560.
  => Resolved with 0e60d11c8281.
- [x] Maybe also implement at `LanStrategy`, not only at `WanBusStrategy`?
  => `LanStrategy` will be dissolved in favor of SensorWAN direct device addressing.
- [ ] What about the data export path?
- [ ] As a followup, what about per-device **downlink** messages?
- [x] Documentation, both for the _generic_ addressing scheme, for example using UUIDs as device identifiers, and the _dashed topic_ addressing scheme, relating to multi-tenant TTN acquisition.
  => Documentation for multi-tenant TTN acquisition will be added with a subsequent patch.
