### PR TITLE
[TTN] Add documentation about multi-tenant data acquisition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ in progress
 
   - ``mqttkit-1/device/123e4567-e89b-12d3-a456-426614174000``
   - ``mqttkit-1/channel/network-gateway-node``
+- [TTN] Add documentation about multi-tenant data acquisition using only
+  a single TTN Application. Thanks, @thiasB, @einsiedlerkrebs, and @ClemensGruber.
+
 
 
 .. _kotori-0.27.0:

--- a/doc/source/_resources.rst
+++ b/doc/source/_resources.rst
@@ -170,10 +170,15 @@
 .. _Raumfahrtagentur: http://www.raumfahrtagentur.org/
 
 .. NEW
+.. _curl: https://en.wikipedia.org/wiki/CURL
 .. _Funky v3: https://harizanov.com/product/funky-v3/
 .. _OpenXC: https://openxcplatform.com/
 .. _OpenXC for Python: http://python.openxcplatform.com/
+.. _multi-tenant: https://en.wikipedia.org/wiki/Multitenancy
 .. _NodeUSB: https://web.archive.org/web/20210621192219/http://www.nodeusb.com/
+.. _trunking: https://en.wikipedia.org/wiki/Trunking
+.. _webhook: https://en.wikipedia.org/wiki/Webhook
+.. _webhooks: https://en.wikipedia.org/wiki/Webhook
 
 
 .. Companies

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,10 +12,16 @@
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx_togglebutton",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.ifconfig",
     "sphinx.ext.graphviz",
+    "sphinxcontrib.mermaid",
+    "sphinxext.opengraph",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -375,6 +381,22 @@ from sphinx.highlighting import lexers
 # Enable highlighting for PHP code not between <?php ... ?> by default
 lexers["php"] = PhpLexer(startinline=True)
 lexers["php-annotations"] = PhpLexer(startinline=True)
+
+
+# -- Options for MyST -------------------------------------------------
+
+myst_heading_anchors = 3
+myst_enable_extensions = [
+    "attrs_block",
+    "attrs_inline",
+    "colon_fence",
+    "deflist",
+    "fieldlist",
+    "html_admonition",
+    "linkify",
+    "strikethrough",
+    "tasklist",
+]
 
 
 # -- Runtime setup --------------------------------------------------------

--- a/doc/source/handbook/acquisition/protocol/http.rst
+++ b/doc/source/handbook/acquisition/protocol/http.rst
@@ -189,6 +189,19 @@ Upload the file all at once::
     cat data.csv | http POST http://localhost:24642/api/mqttkit-1/testdrive/area-42/node-1/data Content-Type:text/csv
 
 
+************
+Integrations
+************
+
+The HTTP data acquisition interface offers integrations with other upstream systems.
+
+The Things Stack + Network
+==========================
+
+The :ref:`integration-tts-ttn` provides efficient integration with the TTS server
+and TTN network, in both single-device and `multi-tenant`_ scenarios.
+
+
 ****************************
 Periodic acquisition example
 ****************************

--- a/doc/source/handbook/decoders/tts-ttn.rst
+++ b/doc/source/handbook/decoders/tts-ttn.rst
@@ -1,6 +1,7 @@
 .. include:: ../../_resources.rst
 
 .. _tts-ttn-decoder:
+.. _integration-tts-ttn:
 
 ###############
 TTS/TTN decoder
@@ -12,47 +13,117 @@ About
 *****
 
 Receive and decode telemetry data from devices on the `The Things Stack (TTS)`_
-/ `The Things Network (TTN)`_.
+/ `The Things Network (TTN)`_, using HTTP `webhooks`_, and store it into timeseries
+databases for near real-time querying.
 
 .. figure:: https://upload.wikimedia.org/wikipedia/commons/b/bb/The_Things_Network_logo.svg
     :target: https://de.wikipedia.org/wiki/The_Things_Network
     :alt: The Things Network logo
     :width: 100px
 
+Overview
+========
 
-*************
-Configuration
-*************
+.. Mermaid Flowcharts documentation: https://mermaid.js.org/syntax/flowchart.html
+
+.. mermaid::
+
+    %%{init: {"flowchart": {"defaultRenderer": "dagre", "htmlLabels": false}} }%%
+
+    flowchart LR
+
+      subgraph sensors [sensor domain]
+        direction LR
+        Device
+      end
+
+      subgraph network [The Things Network]
+        direction TB
+        TTS[The Things Stack\nLoRaWAN Network Server]
+        TTS -.-> Webhook[HTTP Webhook]
+      end
+
+      subgraph backend
+        direction LR
+        Kotori --> InfluxDB
+        Kotori --> Grafana
+      end
+
+      sensors -.- RF/ISM/LoRaWAN -.-> network
+      network ==> backend
+
+Background
+==========
+
+The TTS documentation states that their long-term data storage feature is not suitable
+for real-time querying.
+
+    The `TTS Storage Integration`_ should not be used for querying realtime data. For
+    scalability reasons, writes to the Storage Integration database are performed in batches
+    and there may be a delay after an uplink is received, before it is available. For realtime
+    alerts, use Webhooks.
+
+Glossary
+========
+
+:The Things Stack (TTS): A robust, yet flexible LoRaWAN® Network Server for demanding
+    LoRaWAN deployments, from covering the essentials to advanced security configurations
+    and device life cycle management.
+
+:The Things Network (TTN): An open community-based initiative to build a low-power,
+    wide-area network for the Internet of Things.
+
+:TTS Webhooks: Allows *The Things Stack* to send application related messages to specific
+    HTTP(S) endpoints.
+
+
+*****
+Setup
+*****
 
 Getting the system configured properly is important, please read this section carefully.
 
+Creating a custom webhook
+=========================
 
-The Things Network Console
-==========================
+You will need to use `The Things Network Console`_ at
+https://console.cloud.thethings.network/, in order to `configure a custom Webhook`_.
 
-First, you will need to use `The Things Network Console`_ at
-https://console.cloud.thethings.network/, in order to `configure an outbound Webhook`_.
+On the custom webhook configuration dialog, please enter the following settings:
 
-.. figure:: https://user-images.githubusercontent.com/453543/236702766-850c9bb3-06e8-4372-8192-0cb521d598a0.png
-    :target: https://user-images.githubusercontent.com/453543/236702766-850c9bb3-06e8-4372-8192-0cb521d598a0.png
+- **Webhook ID**
+
+  An arbitrary label identifying the Webhook.
+
+- **Webhook format**
+
+  Choose ``JSON`` here.
+
+- **Base URL**
+
+  Like outlined at the :ref:`daq-http` documentation section, this setting will obtain
+  the full URL to the data acquisition channel, modulo the ``/data`` suffix, which will
+  be added per "Enabled event types" configuration option.
+
+- **Filter event data**
+
+  If you want to filter the submitted telemetry payload, and only submit the nested
+  ``decoded_payload`` data structure, you can use a path accessor expression like
+  ``up.uplink_message.decoded_payload``. Check out all available `filter paths`_.
+
+- **Enabled event types**
+
+  For the event type ``Uplink message``, add the URL path suffix ``/data``.
+
+This screenshot of the corresponding dialog in TTS guides you which parameters to
+configure correspondingly.
+
+.. figure:: https://github.com/daq-tools/kotori/assets/453543/8948044e-8411-44ec-bbe5-100bf925f4dd
+    :target: https://github.com/daq-tools/kotori/assets/453543/8948044e-8411-44ec-bbe5-100bf925f4dd
     :alt: The Things Network Console Webhook configuration
-    :width: 640px
+    :width: 600px
 
     *The Things Network Console Webhook configuration*
-
-Please configure the following settings:
-
-- ``Webhook ID``: An arbitrary label identifying the Webhook.
-- ``Webhook format``: Choose ``JSON`` here.
-- ``Base URL``: Like outlined at the :ref:`daq-http` documentation section, this
-  setting will obtain the full URL to the data acquisition channel, modulo the
-  ``/data`` suffix, which will be added per "Enabled event types" configuration
-  option.
-- ``Filter event data``: If you want to filter the submitted telemetry payload,
-  and only submit the nested ``decoded_payload`` data structure, you can use a
-  path accessor expression like ``up.uplink_message.decoded_payload``.
-- ``Enabled event types``: For the event type ``Uplink message``, add the URL
-  path suffix ``/data``.
 
 .. important::
 
@@ -60,24 +131,63 @@ Please configure the following settings:
     metadata, for example gateway information, please leave the ``Filter event data``
     field empty.
 
-Example
--------
+Now, when the TTN infrastructure receives uplink messages from your device(s), they will
+be delivered to the configured HTTP endpoint in JSON format. Kotori will decode those
+messages transparently.
 
-This would be a corresponding set of example default values::
+Single-device connectivity
+==========================
+
+If you only want to connect a few devices, and want to configure individual webhooks for
+them, you may find it acceptable to create a dedicated `TTS Application`_ **per device**.
+
+A corresponding set of example default values, when using the "wide" channel addressing
+scheme, in order to dispatch messages to channels of individual devices, would be::
 
     Webhook ID:             expert-bassoon
     Webhook format:         JSON
-    Base URL:               https://daq.example.org/api/mqttkit-1/testdrive/area-42/node-1
+    Base URL:               https://daq.example.org/api/sensorwan-1/testdrive/area42/node1
     Filter event data:      up.uplink_message.decoded_payload
     Enabled event types:    /data
 
+.. note::
 
-********
-Examples
-********
+    With this configuration variant, you will configure the full-qualified SensorWAN
+    address within the "Base URL" field of your application.
 
-Now, JSON data payloads submitted from the TTN infrastructure to your system, like those
-examples, will be decoded by Kotori transparently.
+Multi-tenant connectivity
+=========================
+
+The `multi-tenant`_ connectivity option allows you to use a **single** `TTS Application`_
+to serve multiple :ref:`hiveeyes-arduino:sensorwan` networks, in order to support a fleet
+of devices, without needing to create individual, per-device webhooks.
+
+This is a corresponding set of example default values, when using the "direct" channel
+addressing scheme, in order to multiplex channels of different devices using a single
+HTTP endpoint, effectively implementing `trunking`_ data acquisition::
+
+    Webhook ID:             fuzzy-carnival
+    Webhook format:         JSON
+    Base URL:               https://daq.example.org/api/sensorwan-1/channel{/devID}
+    Filter event data:
+    Enabled event types:    /data
+
+.. note::
+
+    This example uses a single webhook configuration based on using the ``{/devID}`` path
+    variable within the "Base URL" field of your application. You can learn about other path
+    variables at `TTS Webhook Path Variables`_.
+
+    It also leaves the "Filter event data" field empty, so you will receive full payloads,
+    including metrics from gateways, etc.
+
+
+****************
+Dry-run examples
+****************
+
+By using the following examples, you can exercise the transmission procedure within
+a dry-run environment / sandbox.
 
 .. literalinclude:: tts-ttn-uplink.json
     :language: json
@@ -87,23 +197,53 @@ Acquire and submit a minimal TTN JSON payload to Kotori's HTTP API.
 .. code-block:: shell
 
     wget https://github.com/daq-tools/kotori/raw/main/test/test_tts_ttn_minimal.json
-    cat test_tts_ttn_minimal.json | http POST https://daq.example.org/api/mqttkit-1/testdrive/area-42/node-minimal/data
+    cat test_tts_ttn_minimal.json | \
+        http POST https://daq.example.org/api/sensorwan-1/testdrive/area42/node1/data
 
 Acquire and submit a full TTN JSON payload to Kotori's HTTP API.
 
 .. code-block:: shell
 
     wget https://github.com/daq-tools/kotori/raw/main/test/test_tts_ttn_full.json
-    cat test_tts_ttn_full.json | http POST https://daq.example.org/api/mqttkit-1/testdrive/area-42/node-full/data
+    cat test_tts_ttn_full.json | \
+        http POST https://daq.example.org/api/sensorwan-1/testdrive/area42/node1/data
+
+.. note::
+
+    | Addressing the same channel using the "direct" variant means replacing
+    | ``/testdrive/area42/node1`` by
+    | ``/channel/testdrive-area42-node1``.
+
+    A full-qualified URL example is::
+
+        https://daq.example.org/api/sensorwan-1/channel/testdrive-area42-node1/data
 
 .. tip::
 
-    For submitting JSON data to the HTTP endpoint of Kotori, the authors recommend the
-    excellent `HTTPie`_ program. However, the same can also be achieved by using ``curl``.
+    For submitting JSON data to the HTTP endpoint of Kotori, the examples above are using
+    the excellent `HTTPie`_ program. Note that the same requests can also be submitted
+    by using the `curl`_ program, or any other HTTP client.
 
 
-.. _configure an outbound Webhook: https://www.thethingsindustries.com/docs/integrations/webhooks/
+******************
+Grafana screenshot
+******************
+
+This is an example screenshot of a `Grafana`_ dashboard, which demonstrates what colleagues
+have been doing with this system.
+
+.. figure:: https://github.com/daq-tools/kotori/assets/453543/45786928-d54a-4052-a124-f4adac3b5604
+    :target: https://swarm.hiveeyes.org/grafana/d/763KRx7mk/freiland-potsdam-thias-lora-multi-hive
+    :alt: LoRaWAN/TTN Grafana example dashboard
+
+
+.. _configure a custom Webhook: https://www.thethingsindustries.com/docs/integrations/webhooks/
+.. _filter paths: https://www.thethingsindustries.com/docs/integrations/webhooks/webhook-templates/format/#field-mask
 .. _HTTPie: https://httpie.io/
 .. _The Things Stack (TTS): https://www.thethingsindustries.com/docs/
 .. _The Things Network (TTN): https://www.thethingsnetwork.org/
 .. _The Things Network Console: https://www.thethingsnetwork.org/docs/network/console/
+.. _The Things Network Console - Creating Webhooks: https://www.thethingsindustries.com/docs/integrations/webhooks/creating-webhooks/
+.. _TTS Application: https://www.thethingsindustries.com/docs/integrations/adding-applications/
+.. _TTS Webhook Path Variables: https://www.thethingsindustries.com/docs/integrations/webhooks/path-variables/
+.. _TTS Storage Integration: https://www.thethingsindustries.com/docs/integrations/storage/

--- a/doc/source/requirements.txt
+++ b/doc/source/requirements.txt
@@ -1,8 +1,10 @@
 furo
 jinja2<4
-pygments<3
 myst-parser[linkify]<2
+pygments<3
 sphinx>=6,<7
 sphinx-copybutton<1
+sphinx-design<1
 sphinx-togglebutton<1
+sphinxcontrib-mermaid<1
 sphinxext-opengraph<1


### PR DESCRIPTION
## About

The idea is to use only a single TTN Application for multiple devices, without needing to (re)configure anything.

## Details

The implementation is based on the SensorWAN "direct" addressing scheme added with GH-136 already, so this patch only adds corresponding documentation.

/cc @ClemensGruber, @thiasB, @einsiedlerkrebs
