### PR TITLE
[core] Fix connecting to MQTT broker without authentication credentials

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ in progress
   - ``mqttkit-1/channel/network-gateway-node``
 - [TTN] Add documentation about multi-tenant data acquisition using only
   a single TTN Application. Thanks, @thiasB, @einsiedlerkrebs, and @ClemensGruber.
-
+- [core] Fix error when connecting to MQTT broker without authentication credentials
 
 
 .. _kotori-0.27.0:

--- a/kotori/io/protocol/target.py
+++ b/kotori/io/protocol/target.py
@@ -42,19 +42,24 @@ class ForwarderTargetService(MultiServiceMixin, MultiService):
         downstream service object for handling the target address scheme.
         """
 
-        log.info(u'Starting {name} for serving address {address}', name=self.logname, address=self.address)
+        log.info('Starting {name} for serving address {address} with scheme {scheme}',
+                 name=self.logname, address=self.address, scheme=self.scheme)
 
         self.settings = self.parent.settings
 
         if self.scheme == 'mqtt':
 
             # Register MqttAdapter service as downstream subsystem service object
-            self.downstream = MqttAdapter(
-                name          = self.name + '-downstream',
-                broker_host   = self.settings.mqtt.host,
-                broker_port   = int(self.settings.mqtt.port),
-                broker_username = self.settings.mqtt.username,
-                broker_password = self.settings.mqtt.password)
+            try:
+                self.downstream = MqttAdapter(
+                    name          = self.name + '-downstream',
+                    broker_host   = self.settings.mqtt.host,
+                    broker_port   = int(self.settings.mqtt.port),
+                    broker_username = self.settings.mqtt.get("username"),
+                    broker_password = self.settings.mqtt.get("password"),
+                )
+            except Exception as ex:
+                log.failure("Connecting to MQTT broker failed: {ex}", ex=last_error_and_traceback())
 
         elif self.scheme == 'influxdb':
             # InfluxDB has no subsystem service, it's just an adapter


### PR DESCRIPTION
Spotted a bug while exercising a basic example on the command line. When not supplying `username` and `password` for MQTT broker authentication, the machinery failed.