### PR TITLE
[export] Improve export transformation capabilities

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ in progress
   a single TTN Application. Thanks, @thiasB, @einsiedlerkrebs, and @ClemensGruber.
 - [core] Fix error when connecting to MQTT broker without authentication credentials
 - [docs] Refactor "decoders" section to "integrations", and improve index/overview page
+- [export] Improve export capabilities by adding parameters ``sort``, ``direction``,
+  ``limit``, and ``scalar``. Thanks, @ClemensGruber.
 
 
 .. _kotori-0.27.0:

--- a/doc/source/handbook/export/index.rst
+++ b/doc/source/handbook/export/index.rst
@@ -160,13 +160,31 @@ This would yield the result with "weight" field omitted::
     2016-07-01 16:58:34.788767764,64.64,48.48
     2016-07-01 16:58:37.645754806,64.64,48.48
 
-There's also the url parameter ``include`` which does things the other way round:
+Include fields
+==============
+There is also the url parameter ``include`` which does things the other way round:
 It will only export the named fields::
 
     http GET $HTTP_URI/api/$MQTT_TOPIC/data.csv include=weight
 
 Both parameters take a comma-separated list of field names.
 
+Sort records
+============
+The URL parameter ``sort`` specifies a field name you would like to sort by, e.g.
+``sort=temperature``. The parameter ``direction`` can be used to control the sort
+oder, e.g. ``direction=desc`` for sorting in descending order. If you omit the
+``direction`` parameter, the sort order is ascending.
+
+Limit result size
+=================
+The ``limit`` parameter controls the number of records to be returned.
+
+Return scalar values
+====================
+In order to return a single scalar value, use the ``scalar`` parameter. It will
+omit any headers. For example, ``sort=time&direction=desc&scalar=humidity`` will
+return the most recent humidity value in the database.
 
 Hierarchical data
 =================
@@ -182,8 +200,4 @@ Todo
 
     Describe parameters::
 
-        include, exclude, pad
-        interpolate=true
-        &from=20160519
-        sorted
-
+        pad, interpolate=true

--- a/kotori/io/protocol/util.py
+++ b/kotori/io/protocol/util.py
@@ -4,7 +4,6 @@ import math
 from datetime import timedelta, datetime
 
 import arrow
-import datetime
 
 from arrow.parser import DateTimeParser
 from six import text_type
@@ -123,7 +122,7 @@ def convert_floats(data, integers=None):
     delete_keys = []
     for key, value in data.items():
         try:
-            if isinstance(value, datetime.datetime):
+            if isinstance(value, datetime):
                 continue
             if is_number(value):
                 if key in integers:

--- a/test/util.py
+++ b/test/util.py
@@ -256,11 +256,16 @@ def http_csv_sensor(topic, data):
     return requests.post(uri, data=body, headers={'Content-Type': 'text/csv'})
 
 
-def http_get_data(path: str = None, format='csv', ts_from=None, ts_to=None, port=24642):
+def http_get_data(path: str = None, format='csv', params=None, ts_from=None, ts_to=None, port=24642):
     path = path.lstrip("/")
-    uri = f'http://localhost:{port}/api/{path}.{format}?from={ts_from}&to={ts_to}'
+    uri = f'http://localhost:{port}/api/{path}.{format}'
     logger.info('HTTP: Exporting data from {} using format "{}"'.format(uri, format))
-    payload = requests.get(uri).content
+    params = params or {}
+    if ts_from:
+        params["from"] = ts_from
+    if ts_to:
+        params["to"] = ts_to
+    payload = requests.get(uri, params=params).content
     if format in ["csv", "txt", "json", "html"]:
         payload = payload.decode()
     return payload


### PR DESCRIPTION
## About

Added new HTTP export API query parameters `sort`, `direction`, `limit`, and `scalar`.

## Example

```
http "https://swarm.hiveeyes.org/api/hiveeyes/zku/paxcounter/bauschilderung/data.json?from=now-5m&sort=time&direction=desc&limit=1&scalar=pax"
```

## References

- https://community.hiveeyes.org/t/den-aktuellsten-publizierten-datensatz-oder-einzelwert-eines-bestimmten-datenkanals-abrufen/4966

## Backlog
- ~~[x] Documentation is missing.~~

/cc @ClemensGruber