### PR TITLE
Documentation: Maintenance and copy editing. Add SensorWAN 3.0 specification page.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ in progress
 
   - ``mqttkit-1/device/123e4567-e89b-12d3-a456-426614174000``
   - ``mqttkit-1/channel/network-gateway-node``
+- [SensorWAN] Added the :ref:`SensorWAN 3.0 specification <sensorwan-spec>` page
+  to the documentation.
 - [TTN] Added decoder for TTS/TTN (The Things Stack, The Things Network).
   Thanks, @thiasB and @u-l-m-i.
 - [TTN] Started decoding metadata from full TTN payload. Thanks, @thiasB.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,85 +6,98 @@ Changelog
 in progress
 ===========
 
-- CI: Validated against Grafana 9.5.21, 10.4.19, 11.6.9, 12.3.2
-- Grafana: Only permit numeric fields to be established on Graph panels.
-  Other types will make the panel croak like
+.. rubric:: DAQ
+
+- [MQTT] Fixed error when connecting to MQTT broker without authentication credentials.
+- [HTTP] Improved export capabilities by adding parameters ``sort``, ``direction``,
+  ``limit``, and ``scalar``. Thanks, @ClemensGruber.
+- [Grafana] Started permitting only numeric fields to be established on graph panels.
+  Other types would make the panel raise errors like
   ``InfluxDB Error: unsupported mean iterator type: *query.stringInterruptIterator``
   or ``InfluxDB Error: not executed``.
-- Documentation: Modernize documentation and migrate to Read the Docs
-  https://kotori.readthedocs.io/
-- [TTN] Add TTS (The Things Stack) / TTN (The Things Network) decoder.
-  Thanks, @thiasB and @u-l-m-i.
-- [TTN] Decode metadata from full TTN payload. Thanks, @thiasB.
-- [DA] Add per-device addressing and topic decoding strategies. Thanks,
+
+.. rubric:: Integrations
+
+- [SensorWAN] Added per-device addressing and topic decoding strategies. Thanks,
   @thiasB and @ClemensGruber. Examples:
 
   - ``mqttkit-1/device/123e4567-e89b-12d3-a456-426614174000``
   - ``mqttkit-1/channel/network-gateway-node``
-- [TTN] Add documentation about multi-tenant data acquisition using only
+- [TTN] Added decoder for TTS/TTN (The Things Stack, The Things Network).
+  Thanks, @thiasB and @u-l-m-i.
+- [TTN] Started decoding metadata from full TTN payload. Thanks, @thiasB.
+- [TTN] Added documentation about multi-tenant data acquisition using only
   a single TTN Application. Thanks, @thiasB, @einsiedlerkrebs, and @ClemensGruber.
-- [core] Fix error when connecting to MQTT broker without authentication credentials
-- [docs] Refactor "decoders" section to "integrations", and improve index/overview page
-- [export] Improve export capabilities by adding parameters ``sort``, ``direction``,
-  ``limit``, and ``scalar``. Thanks, @ClemensGruber.
-- Dependencies: Downgrade to setuptools v80 to bring back ``pkg_resources``
-- Runtime: Validated support on Python 3.12, 3.13, 3.14
-- Runtime: Relaxed dependency specifications
+- Documentation: Refactored "decoders" section to "integrations", and improve
+  ``index/overview`` page.
+
+.. rubric:: Maintenance
+
+- Documentation: Modernized documentation and migrate to Read the Docs.
+
+  See https://kotori.readthedocs.io/.
+- CI: Validated support on Python 3.12, 3.13, 3.14.
+- CI: Validated against Grafana 9.5.21, 10.4.19, 11.6.9, 12.3.2.
+- Python: Downgraded to ``setuptools`` v80 to bring back ``pkg_resources``.
+- Python: Relaxed dependency specifications.
 
 
 .. _kotori-0.27.0:
 
 2022-11-26 0.27.0
 =================
-- Add documentation about running Kotori with RabbitMQ as MQTT broker, see
-  :ref:`mqtt-broker-rabbitmq`
-- Allow connecting to individual MQTT broker per application
-- Improve MQTT logging when connection to broker fails
-- Make MQTT broker credential settings ``username`` and ``password`` optional
-- Adjust logging format re. milli/microseconds
-- Because accessing dashboards by slug has been removed with Grafana 8, Kotori
-  will now use the slug-name of the data channel for all of Grafana's ``uid``,
-  ``name`` and ``title`` fields.
-- Improve decoding fractional epoch timestamps
-- Update to ``numpy<1.24`` on Python >3.10
-- Replace ``Bunch`` with ``Munch``
 
-Breaking changes
-----------------
-- Stop converging ``latitude`` and ``longitude`` ingress fields to tags.
+.. rubric:: DAQ
+
+- [Core] Adjusted logging format re. milli/microseconds
+- [Core] Improved decoding fractional epoch timestamps
+- [MQTT] Allowed connecting to individual MQTT broker per application.
+- [MQTT] Improved MQTT logging when connection to broker fails.
+- [MQTT] Made MQTT broker credential settings ``username`` and ``password`` optional.
+- [MQTT] Added documentation about running Kotori with RabbitMQ as MQTT
+  broker, see :ref:`mqtt-broker-rabbitmq`.
+- [Grafana] Accompanied Grafana 8: Because accessing dashboards by slug was removed
+  with Grafana 8, Kotori will now use the slug-name of the data channel for all
+  of Grafana's ``uid``, ``name`` and ``title`` fields.
+
+.. rubric:: Breaking changes
+
+- [DAQ] Stopped converging ``latitude`` and ``longitude`` ingress fields to tags.
   It has been implemented as a convenience case when processing LDI data,
   but it is not applicable in standard data acquisition scenarios, specifically
   when recording positions of moving objects. Thanks, @tonkenfo.
 
-Infrastructure
---------------
-- Improve sandbox and CI setup, software tests and documentation
-- Update to Twisted <23
-- CI: Update to Grafana 7.5.17, 8.5.15, and 9.2.6
-- CI: Update to MongoDB 5.0
-- Tests: Remove ``nosetests`` test runner, replace with ``pytest``
-- Build: Use ``python -m build`` for building sdist and wheel packages
-- Add support for Python 3.10 and 3.11
-- Drop support for Python 3.5 and 3.6
-- CI: Modernize GHA workflow recipe
-- Documentation: Add link checker and fix a few broken links
-- Documentation: Update to Sphinx 5
+.. rubric:: Maintenance
 
-Tests
------
-- Add software tests for simulating all advanced actions against Grafana.
+- Improved sandbox and CI setup, software tests and documentation
+- Updated to Twisted <23
+- CI: Updated to Grafana 7.5.17, 8.5.15, and 9.2.6
+- CI: Updated to MongoDB 5.0
+- Tests: Removed ``nosetests`` test runner, replace with ``pytest``
+- Build: Used ``python -m build`` for building sdist and wheel packages
+- Added support for Python 3.10 and 3.11
+- Dropped support for Python 3.5 and 3.6
+- CI: Modernized GHA workflow recipe
+- Documentation: Added link checker and fix a few broken links
+- Documentation: Updated to Sphinx 5
+- Updated to ``numpy<1.24`` on Python >3.10
+- Replaced ``Bunch`` with ``Munch``
 
-  - Publish single reading in JSON format to MQTT broker and proof that a
-    corresponding datasource and a dashboard was created in Grafana.
-  - Publish two subsequent readings in JSON format to MQTT broker and
-    proof that a corresponding datasource and a dashboard was first
-    created and then updated in Grafana.
-  - Publish two subsequent readings to two different topics and proof that
-    a corresponding datasource and a dashboard with two panels has been
-    created in Grafana.
-  - Publish two subsequent readings to two different topics and proof that
-    a corresponding datasource and two dashboards have been created in
-    Grafana.
+.. rubric:: Tests
+
+Added software tests for simulating all advanced actions against Grafana.
+
+- Publish single reading in JSON format to MQTT broker and proof that a
+  corresponding datasource and a dashboard was created in Grafana.
+- Publish two subsequent readings in JSON format to MQTT broker and
+  proof that a corresponding datasource and a dashboard was first
+  created and then updated in Grafana.
+- Publish two subsequent readings to two different topics and proof that
+  a corresponding datasource and a dashboard with two panels has been
+  created in Grafana.
+- Publish two subsequent readings to two different topics and proof that
+  a corresponding datasource and two dashboards have been created in
+  Grafana.
 
 
 .. _kotori-0.26.12:

--- a/Makefile
+++ b/Makefile
@@ -100,15 +100,15 @@ test-coverage: virtualenv-dev
 # Build Sphinx documentation.
 docs-html: virtualenv-docs
 	touch doc/source/index.rst
-	$(sphinx-build) -j auto -n -W --keep-going -b html doc/source doc/build
+	$(sphinx-build) --jobs auto -n -W --keep-going -b html doc/source doc/build
 
 docs-autobuild: virtualenv-docs
 	$(pip) install sphinx-autobuild
-	$(sphinx-autobuild) --open-browser doc/source doc/build
+	$(sphinx-autobuild) --jobs auto --open-browser doc/source doc/build
 
 # Run link checker on documentation.
 docs-linkcheck: virtualenv-docs
-	$(sphinx-build) -j auto -n -W --keep-going -b linkcheck doc/source doc/build
+	$(sphinx-build) --jobs auto -n -W --keep-going -b linkcheck doc/source doc/build
 
 
 # Upload media assets. Images, videos, etc.

--- a/README.rst
+++ b/README.rst
@@ -134,12 +134,10 @@ Features
 Installation
 ************
 
-Kotori can be installed in different ways. You may prefer using a Debian
-package, install it from the Python Package Index (PyPI), or run it within
-a `development sandbox`_ directly from the Git repository.
-
-Corresponding installation instructions are bundled at
-https://kotori.readthedocs.io/setup/.
+Kotori can be installed in different ways, see `all installation options`_.
+You may prefer using a Debian package, install it from the Python Package
+Index (PyPI), or run it within a development environment directly from the
+Git repository, see `sandbox installation instructions`_.
 
 
 ********
@@ -229,6 +227,7 @@ Special thanks to the people at JetBrains s.r.o. for supporting us with
 excellent development tooling.
 
 
+.. _all installation options: https://kotori.readthedocs.io/setup/
 .. _Autobahn: https://crossbar.io/autobahn/
 .. _contributors: https://kotori.readthedocs.io/project/contributors.html
 .. _Create an issue: https://github.com/daq-tools/kotori/issues/new
@@ -244,6 +243,7 @@ excellent development tooling.
 .. _Mosquitto: https://github.com/eclipse/mosquitto
 .. _MQTT: https://en.wikipedia.org/wiki/MQTT
 .. _Python: https://www.python.org/
+.. _sandbox installation instructions: https://kotori.readthedocs.io/setup/sandbox.html
 .. _SCADA: https://en.wikipedia.org/wiki/SCADA
 .. _scenarios: https://kotori.readthedocs.io/about/scenarios.html
 .. _technologies: https://kotori.readthedocs.io/about/technologies.html

--- a/doc/source/_resources.rst
+++ b/doc/source/_resources.rst
@@ -3,11 +3,11 @@
 .. Links to external resources
 
 .. Kotori service
-.. _Kotori: https://www.getkotori.org/
+.. _Kotori: https://kotori.readthedocs.io/
 .. _DAQ core router: https://github.com/daq-tools/kotori/blob/0.24.5/kotori/daq/services/mig.py
 .. _WanBusStrategy: https://github.com/daq-tools/kotori/blob/0.26.12/kotori/daq/strategy/wan.py
-.. _MQTTKit communication flavor: https://getkotori.org/docs/handbook/mqttkit.html
-.. _MQTTKit addressing scheme: https://getkotori.org/docs/handbook/mqttkit.html#addressing
+.. _MQTTKit communication flavor: https://kotori.readthedocs.io/handbook/configuration/mqttkit.html
+.. _MQTTKit addressing scheme: https://kotori.readthedocs.io/handbook/configuration/mqttkit.html
 
 
 .. Kotori development

--- a/doc/source/integration/index.md
+++ b/doc/source/integration/index.md
@@ -119,13 +119,13 @@ Measurement readings can be acquired through HTTP, using JSON, CSV, or other pay
 
 :::{grid-item}
 :columns: 8
-#### {ref}`sensorwan`
+### {ref}`sensorwan`
 
 The SensorWAN channel addressing scheme can be used for assigning telemetry
 data communication channels to individual sensor nodes in wide-area sensor
 network scenarios, or similar multi-node, multi-sensor environments.
 
-It is able to handle addressing individual devices and channel bundles in
+It can handle addressing individual devices and channel bundles in
 a natural way, enabling both direct and trunking communications.
 
 <small>
@@ -159,7 +159,7 @@ a natural way, enabling both direct and trunking communications.
 
 :::{grid-item}
 :columns: 8
-#### [](#integration-airrohr)
+#### :ref:`integration-airrohr`
 
 Receive and record telemetry data from air particulate measurement devices of the
 Sensor.Community (formerly Luftdaten.Info) project, running the Airrohr Firmware.

--- a/doc/source/integration/index.md
+++ b/doc/source/integration/index.md
@@ -20,6 +20,14 @@ with Kotori. Adding more integrations is possible.
 ```
 
 ```{toctree}
+:caption: Conventions
+:maxdepth: 1
+:hidden:
+
+SensorWAN <sensorwan/index>
+```
+
+```{toctree}
 :caption: Device/vendor integrations
 :maxdepth: 1
 :hidden:
@@ -98,8 +106,47 @@ Measurement readings can be acquired through HTTP, using JSON, CSV, or other pay
 ::::::
 
 
+## Conventions
 
-## Device/vendor integrations
+::::::{grid} 1
+:margin: 0
+:padding: 0
+
+:::::{grid-item-card}
+::::{grid} 2
+:margin: 0
+:padding: 0
+
+:::{grid-item}
+:columns: 8
+#### {ref}`sensorwan`
+
+The SensorWAN channel addressing scheme can be used for assigning telemetry
+data communication channels to individual sensor nodes in wide-area sensor
+network scenarios, or similar multi-node, multi-sensor environments.
+
+It is able to handle addressing individual devices and channel bundles in
+a natural way, enabling both direct and trunking communications.
+
+<small>
+<strong>Categories:</strong> polyglot, multi-sensor, multi-device, open source specification
+</small>
+:::
+:::{grid-item}
+:columns: 4
+{bdg-primary-line}`network` {bdg-primary-line}`bus:any` {bdg-primary-line}`request-response:any`
+
+{bdg-success-line}`MANY`
+
+{bdg-secondary-line}`MANY`
+:::
+::::
+:::::
+
+::::::
+
+
+## Vendors
 
 ::::::{grid} 1
 :margin: 0
@@ -129,44 +176,6 @@ global sensor network
 {bdg-success-line}`SPS30` {bdg-success-line}`SDS011` {bdg-success-line}`BMP180` {bdg-success-line}`BMP/E 280` {bdg-success-line}`NEO-6M` {bdg-success-line}`DHT22` 
 
 {bdg-secondary-line}`esp8266`
-:::
-::::
-:::::
-
-::::::
-
-
-::::::{grid} 1
-:margin: 0
-:padding: 0
-
-:::::{grid-item-card}
-::::{grid} 2
-:margin: 0
-:padding: 0
-
-:::{grid-item}
-:columns: 8
-#### [](inv:hiveeyes-arduino#sensorwan)
-
-The SensorWAN channel addressing scheme can be used for assigning telemetry
-data communication channels to individual sensor nodes in wide-area sensor
-network scenarios, or similar multi-node, multi-sensor environments.
-
-It is able to handle addressing individual devices and channel bundles in
-a natural way, enabling both direct and trunking communications.
-
-<small>
-<strong>Categories:</strong> polyglot, multi-sensor, multi-device, open source specification
-</small>
-:::
-:::{grid-item}
-:columns: 4
-{bdg-primary-line}`network` {bdg-primary-line}`bus:any` {bdg-primary-line}`request-response:any`
-
-{bdg-success-line}`MANY`
-
-{bdg-secondary-line}`MANY`
 :::
 ::::
 :::::

--- a/doc/source/integration/sensorwan/index.md
+++ b/doc/source/integration/sensorwan/index.md
@@ -1,0 +1,15 @@
+(sensorwan)=
+
+# SensorWAN
+
+> The SensorWAN channel addressing scheme can be used for assigning telemetry
+data communication channels to individual sensor nodes in wide-area sensor
+network scenarios, or similar multi-node, multi-sensor environments.
+>
+> -- {ref}`sensorwan-spec`
+
+:::{toctree}
+:maxdepth: 1
+:hidden:
+Specification <sensorwan-spec>
+:::

--- a/doc/source/integration/sensorwan/sensorwan-spec.rst
+++ b/doc/source/integration/sensorwan/sensorwan-spec.rst
@@ -140,7 +140,7 @@ Name
 Channel type
 ************
 
-On the last segment of a full-qualified channel specifier, the addressing scheme adds
+On the last segment of a fully qualified channel specifier, the addressing scheme adds
 a suffix component, which designates the channel type. It can be used to discriminate
 between uplink, downlink, and other message types.
 

--- a/doc/source/integration/sensorwan/sensorwan-spec.rst
+++ b/doc/source/integration/sensorwan/sensorwan-spec.rst
@@ -1,0 +1,330 @@
+.. include:: ../../_resources.rst
+
+.. _sensorwan-spec:
+
+###########################
+SensorWAN 3.0 specification
+###########################
+
+.. highlight:: text
+
+*****
+About
+*****
+
+The SensorWAN channel addressing scheme can be used for assigning telemetry
+data communication channels to individual `sensor nodes`_ in wide-area `sensor
+network`_ scenarios, or similar multi-node, multi-sensor environments.
+
+
+***********
+Description
+***********
+
+The addressing scheme is essentially a path string using exactly four address
+components.
+
+::
+
+    <realm>/<network>/<group>/<name>
+
+As such, it maps 1:1 to MQTT topics and HTTP URL paths, and provides other means
+for protocols which do not support path-based addressing.
+
+SensorWAN is not an interoperability protocol, and as such, does not implement
+device discovery mechanisms like `Home Assistant MQTT device discovery`_ or
+`Sparkplug`_ do.
+
+Instead, it is primarily a convention for implementing telemetry data transport
+subsystems, supported by corresponding reference implementations like `Kotori`_,
+`Terkin MicroPython Datalogger`_, and `TerkinTelemetry C++`_.
+
+
+********
+Features
+********
+
+- **Real-world topology.**
+
+  The channel address reflects the real-world topology, and is not obstructed by
+  any technical details, similar to the Sparkplug B principle.
+
+  This makes it easy to understand the topology of the sensor network, and to inspect
+  the communication channels without further ado, and without much prior knowledge or
+  technical assistance.
+
+- **Freedom in topic design.**
+
+  The four address components ``realm``, ``network``, ``group``, and ``name``, can be
+  freely adjusted to fit the jargon and semantics of your application or data acquisition
+  scenario, see also :ref:`sensorwan-address-examples`.
+
+- **Infinite number of channels.**
+
+  The "wide" addressing scheme allows to address an arbitrary number of channels,
+  located at any level of the address hierarchy.
+
+- **Semantic grouping of channels.**
+
+  Without any need for a registry and corresponding machineries, you are able to quickly
+  establish address conventions. For example, it is both sensible and advisable to use
+  address prefixes like ``<realm>/testdrive`` for designating channels to be exclusively
+  used for testing purposes.
+
+- **Permission control.**
+
+  Optionally, permission control can be established in a way coherent to channel
+  addresses, where individual permissions can be adjusted according to the hierarchical
+  levels of the network/channel topology, for example, by using MQTT topic ACLs.
+
+
+***************
+Channel address
+***************
+
+This section explains the four individual address components of the *SensorWAN
+channel addressing scheme*, reflecting the data channel topology hierarchy.
+
+::
+
+    realm/network/group/name
+
+Realm
+=====
+
+``realm`` is the designated **system channel root**, implemented as a channel address prefix.
+
+It will be assigned by the operator of the data acquisition system. Operating multiple realms
+on the topmost address level effectively implements system-level `multi-tenancy`_.
+
+When using `Kotori`_, it will be configured within the server configuration files, and as such,
+is a "fixed" address component.
+
+Network
+=======
+
+``network`` is your **personal channel root**, it designates the unique **user/owner**
+of the channel.
+
+This identifier is used to separate channel groups, and to assign them to individual
+users, effectively implementing user-level `multi-tenancy`_.
+
+SensorWAN does not impose any restriction on the format of the ``network`` identifier.
+For maximum uniqueness, use UUIDv4. For better readability, use a custom identifier.
+
+Group
+=====
+
+The ``group`` identifier addresses the **channel group**. You can assign it as you like.
+
+For example, you can group your channels by reflecting locations/sites of your sensor
+nodes, or names of intermediary data concentrators/hubs/gateways.
+
+Name
+====
+
+``name`` designates the channel name. For example, you can use it to reflect the
+**device/node identifier**. Choose anything you like.
+
+----
+
+.. tip::
+
+    In order to assign unique values as address components, you can generate them by using
+    online or standalone programs, see :ref:`sensorwan-unique-identifiers`. In order to
+    get a few ideas about possible topology address implementations, have a look at the
+    :ref:`sensorwan-address-examples`.
+
+
+************
+Channel type
+************
+
+On the last segment of a full-qualified channel specifier, the addressing scheme adds
+a suffix component, which designates the channel type. It can be used to discriminate
+between uplink, downlink, and other message types.
+
+Uplink messages
+===============
+
+Data uplink messages are received from a device. SensorWAN currently discriminates
+between ``/data``- and ``/event``-type messages/suffixes.
+
+Downlink messages
+=================
+
+For pushing downlink messages to devices, SensorWAN uses the ``/downlink`` path suffix.
+
+
+.. _sensorwan-direct-addressing:
+
+*****************
+Direct addressing
+*****************
+
+With SensorWAN 3.0, two "direct" addressing schemes have been added, which can be used to
+directly address channels and devices, either by using their identifiers as opaque labels,
+or by encoding the channel topology differently than using a path-based scheme. For example,
+the "dash" character can be used to separate topology fragments.
+
+::
+
+    # Addressing a device.
+    <realm>/device/123e4567-e89b-12d3-a456-426614174000
+
+    # Addressing a channel.
+    <realm>/channel/<network>-<group>-<name>
+
+Therefore, the ``channel`` and ``device`` labels became reserved identifiers within the
+``network`` namespace.
+
+
+********************************
+Topology mapping and translation
+********************************
+
+The *SensorWAN channel addressing scheme* defines a few conventions how to transparently
+map the channel address from the transport protocol domain to addressing schemes of
+other backend systems, like storage components.
+
+Databases
+=========
+
+For databases following the classic ``database`` -> ``table`` addressing scheme, or
+corresponding variants, the topology mapping from a path-based topic may look like::
+
+    SensorWAN address: <realm>/<network>/<group>/<name>
+    Database name:     <realm>_<network>
+    Table name:        <group>_<name>
+
+Message buses
+=============
+
+For message bus systems following a path-based addressing scheme, the channel address usually
+can be used 1:1 across system boundaries. On specific occasions, it makes sense to translate
+topic identifiers to the syntax conventions used in downstream systems. For example, AMQP
+usually encodes topic identifiers (here: routing keys) with fragments separated by dots. In
+this case, a topic identifier mapping may look like::
+
+    SensorWAN address: <realm>/<network>/<group>/<name>
+    AMQP routing key:  <realm>.<network>.<group>.<name>
+
+Object stores
+=============
+
+In S3, buckets and objects are the primary resources, and objects are stored in buckets.
+S3 has a flat structure instead of a hierarchy like you would see in a file system.
+However, for the sake of organizational simplicity, the folder concept is usually
+synthesized as a means of grouping objects.
+
+Building upon the SensorWAN path-based addressing scheme, a suitable object address within
+an S3 bucket would be, for example, ``<realm>/<network>/<group>/<name>.parquet``.
+
+
+***************
+Payload formats
+***************
+
+SensorWAN does not impose any constraints on payload formats. You are free to select
+anything which fits your needs. However, it provides a mechanism to convey content
+type information over transport links which do not offer corresponding metadata fields,
+like HTTP's ``Content-Type`` header.
+
+For example, `MQTT`_ version 3 does not provide any means to signal the content type,
+so the convention is to add the file extension of the corresponding format to the
+channel type suffix.
+
+For example, in a typical scenario where devices are submitting JSON data payloads
+over MQTTv3 on the "data" channel, a corresponding full channel path specifier would
+add a ``/data.json`` suffix to the channel base address.
+
+::
+
+    <realm>/<network>/<group>/<name>/data.json
+
+
+********
+Appendix
+********
+
+.. _sensorwan-address-examples:
+
+Addressing examples
+===================
+
+To give you a few examples of possible addressing topologies for more specific use-cases:
+
+- | **continent/country/region/city**
+  | Addressing a global/world-wide scenario, or corresponding variants thereof.
+
+- | **amazonas/ecuador/cuyabeno/hydro-1**
+  | When looking at a more regional scenario instead. This is the canonical topology example we
+  | are using on a few spots in the documentation of the reference implementations.
+
+- | **organization/beekeeper/apiary/hive**
+  | The data acquisition topology of the Hiveeyes project.
+
+- | **organization/plant/shop-floor/machine**
+  | For addressing industrial data acquisition scenarios.
+
+.. _sensorwan-unique-identifiers:
+
+Unique identifiers
+==================
+
+In order to assign unique values as address components, you can generate them by using
+online or standalone programs.
+
+For example, generate UUIDs, like ``34f83b61-9044-4ca8-b310-84f412175a4d`` using the
+`Online UUID Generator`_, or generate UUIDs and other kinds of random identifiers more
+suitable for human consumption using the `Vasuki`_ identifier generator, which you can
+use on your own systems as either a command line program, or as a library.
+
+.. tip::
+
+    If you don't fancy UUIDs, and would like to use shorter identifiers instead, like ``re69x8``,
+    or ``ZgBxoo``, saving bandwidth both on the wire and on human communication about them, we
+    recommend to use *Nagamani19*. Nagamani19 is a short, unique, non-sequential identifier
+    based on `Hashids`_ and a custom Epoch starting on January 1, 2019.
+
+    For generating random, pronounceable pseudo-words like ``blaumaueff``, or ``schnoerr``,
+    we recommend to use the *Gibberish* generator.
+
+    Even shorter names, like ``Gime``, ``Togu``, or ``Viku``, suitable for assigning individual
+    device names in a scenario with a few devices can be generated by using epoch slugs,
+    available through the *MomentName* generator.
+
+
+History
+=======
+
+The SensorWAN convention has originally been conceived on behalf of the Hiveeyes project.
+In this context, and with its initial implementation as a channel address decoding
+strategy for the `Kotori`_ data historian, it had different names, like »MQTT topic
+addressing with a quadruple hierarchy strategy«, and later, just »MQTTKit«.
+
+- Oct 19, 2015: Version 0.1 and 0.2 -- A `BERadio extension`_ for the `Hiveeyes One topology`_,
+  defining the `Hiveeyes channel addressing`_.
+- Mar 28, 2016: Version 1.0 -- Materialize as `Kotori's WanBusStrategy`_.
+- Mar 9, 2020: Version 2.0 -- Document as :ref:`Kotori's MQTTKit application <application-mqttkit>`.
+- Jun 6, 2023: Version 3.0 -- Naming things and direct-device addressing: :ref:`SensorWAN 3.0 <sensorwan-spec>`.
+
+
+.. _BERadio extension: https://hiveeyes.org/docs/beradio/README.html#the-main-workhorse
+.. _Hiveeyes channel addressing: https://hiveeyes.org/docs/system/acquisition/
+.. _Hiveeyes One topology: https://hiveeyes.org/docs/system/vendor/hiveeyes-one/topology.html
+.. _Kotori's WanBusStrategy: https://github.com/daq-tools/kotori/blob/main/kotori/daq/strategy/wan.py
+.. _sensor node: https://en.wikipedia.org/wiki/Sensor_node
+.. _sensor nodes: https://en.wikipedia.org/wiki/Sensor_node
+.. _sensor network: https://en.wikipedia.org/wiki/Wireless_sensor_network
+.. _sensor networks: https://en.wikipedia.org/wiki/Wireless_sensor_network
+
+.. _Hashids: https://hashids.org/
+.. _Home Assistant MQTT device discovery: https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
+.. _multi-tenancy: https://en.wikipedia.org/wiki/Multitenancy
+.. _Online UUID Generator: https://www.uuidgenerator.net/
+.. _Sparkplug: https://sparkplug.eclipse.org/
+.. _Terkin MicroPython Datalogger: https://github.com/hiveeyes/terkin-datalogger
+.. _TerkinTelemetry: https://hiveeyes.org/docs/arduino/TerkinTelemetry/README.html
+.. _TerkinTelemetry C++: https://hiveeyes.org/docs/arduino/TerkinTelemetry/README.html
+.. _Vasuki: https://api.hiveeyes.org/vasuki/

--- a/doc/source/requirements.txt
+++ b/doc/source/requirements.txt
@@ -2,7 +2,7 @@ furo
 jinja2<4
 myst-parser[linkify]<6
 pygments<3
-sphinx>=6,<9
+sphinx>=6,<10
 sphinx-copybutton<1
 sphinx-design<1
 sphinx-togglebutton<1

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(name='kotori',
       keywords='data acquisition graphing export plotting daq routing engine ' +
                'mqtt http rest amqp wamp sql web html csv json cdf hdf5 png ' +
                'twisted pyramid autobahn influxdb mosquitto grafana mongodb matplotlib ggplot ' +
-               'telemetry m2m iot',
+               'telemetry m2m iot sensor-network sensorwan',
       packages=find_packages(include=["kotori*"], exclude=["tasks", "test"]),
       include_package_data=True,
       package_data={


### PR DESCRIPTION
## About
This and that.

## Preview
https://kotori--245.org.readthedocs.build/
https://kotori--245.org.readthedocs.build/integration/sensorwan/sensorwan-spec.html

## Details
- [Update to Sphinx 9](https://github.com/daq-tools/kotori/commit/d689a3642d79fe9c452e8fc93ef3acb542c8ae78)
- [Add SensorWAN 3.0 specification page](https://github.com/daq-tools/kotori/commit/38d3b00373a7381d8b99e01a32c899a0126579fc)