### PR TITLE
CI: Verify compatibility with Grafana 12.4.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,9 +34,9 @@ jobs:
         ]
         mosquitto-version: [ "2.0" ]
         influxdb-version: [ "1.8" ]
-        grafana-version: [ "12.3.2" ]
+        grafana-version: [ "12.4.0" ]
         
-#        include:
+        include:
 #          - grafana-version: "7.5.17"
 #            python-version: "3.14"
 #            mosquitto-version: "2.0"
@@ -57,11 +57,16 @@ jobs:
 #            mosquitto-version: "2.0"
 #            influxdb-version: "1.8"
 #            os: "ubuntu-22.04"
-#          - grafana-version: "11.6.9"
+#          - grafana-version: "11.6.12"
 #            python-version: "3.14"
 #            mosquitto-version: "2.0"
 #            influxdb-version: "1.8"
 #            os: "ubuntu-22.04"
+          - grafana-version: "12.3.4"
+            python-version: "3.14"
+            mosquitto-version: "2.0"
+            influxdb-version: "1.8"
+            os: "ubuntu-22.04"
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:


### PR DESCRIPTION
Grafana 12.4.0 was released on 2026-02-24, and includes a few breaking changes by removing API endpoints that have previously been flagged for deprecation.

- https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v12-4/
- https://github.com/grafana/grafana/blob/main/CHANGELOG.md#1240-2026-02-24