### PR TITLE
CI: Use `uv` for installing dependency packages for faster workflow runs

### DIFF
--- a/.github/workflows/requirements-overrides.txt
+++ b/.github/workflows/requirements-overrides.txt
@@ -1,0 +1,4 @@
+# Error on CI/GHA with Python 3.7 when using `uv`.
+# Failed to build `netcdf4==1.6.5`.
+# Package hdf5 was not found in the pkg-config search path.
+netcdf4>=1.5.3,<1.8; python_version>="3.8"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Run tests, with coverage
         run: |
-          make test-coverage
+          uv run poe test-coverage
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Install dependency packages
         run: |
           uv venv --seed .venv
-          uv pip install --upgrade --editable='.[full,test]'
+          uv pip install --upgrade --editable='.[full,test]' --overrides .github/workflows/requirements-overrides.txt
 
       - name: Run tests, with coverage
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,9 @@ jobs:
       matrix:
         os: [ "ubuntu-22.04" ] # , macos-latest, windows-latest ]
         python-version: [
-          "3.7",
+          # TODO: Bring back Python 3.7.
+          # https://github.com/astral-sh/setup-uv/issues/772
+          # "3.7",
           "3.8",
           "3.9",
           "3.10",

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,6 @@ jobs:
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
-      UV_SYSTEM_PYTHON: true
 
     name: Python ${{ matrix.python-version }}, Grafana ${{ matrix.grafana-version }}, Mosquitto ${{ matrix.mosquitto-version }}, InfluxDB ${{ matrix.influxdb-version }}
     steps:
@@ -109,20 +108,10 @@ jobs:
           config: ${{ github.workspace }}/etc/test/mosquitto-no-auth.conf
           # container-name: 'mqtt'
 
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: x64
-          cache: 'pip'
-          cache-dependency-path: |
-            setup.py
-
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:
-          cache-dependency-glob: |
-            setup.py
+          activate-environment: true
           cache-suffix: ${{ matrix.python-version }}
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -130,7 +119,6 @@ jobs:
 
       - name: Install dependency packages
         run: |
-          uv venv --seed .venv
           uv pip install --upgrade --editable='.[full,test]' --overrides .github/workflows/requirements-overrides.txt
 
       - name: Run tests, with coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,7 @@ jobs:
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
+      UV_SYSTEM_PYTHON: true
 
     name: Python ${{ matrix.python-version }}, Grafana ${{ matrix.grafana-version }}, Mosquitto ${{ matrix.mosquitto-version }}, InfluxDB ${{ matrix.influxdb-version }}
     steps:
@@ -116,6 +117,21 @@ jobs:
           cache: 'pip'
           cache-dependency-path: |
             setup.py
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          cache-dependency-glob: |
+            setup.py
+          cache-suffix: ${{ matrix.python-version }}
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+          version: 'latest'
+
+      - name: Install dependency packages
+        run: |
+          uv venv --seed .venv
+          uv pip install --upgrade --editable='.[full,test]'
 
       - name: Run tests, with coverage
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,18 @@ omit = [
   "kotori/vendor/luftdaten/*",
   "kotori/vendor/lst/*",
 ]
+
+[tool.poe.tasks]
+test = [
+  {cmd="pytest kotori test"},
+]
+test-coverage = [
+  {cmd="coverage erase"},
+  {shell="coverage run --concurrency=multiprocessing,thread --parallel-mode --timid $(command -v pytest) kotori test"},
+  {cmd="coverage combine"},
+  {cmd="coverage report"},
+  {cmd="coverage xml"},
+]
+check = [
+  "test",
+]

--- a/setup.py
+++ b/setup.py
@@ -213,6 +213,7 @@ setup(name='kotori',
             'pytest-twisted<2',
             'datadiff<3',
             'coverage<8',
+            'poethepoet<1',
         ],
         'release': [
             'build',

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -5,6 +5,8 @@ import json
 import logging
 
 import io
+import sys
+
 import pandas as pd
 import pytest
 import pytest_twisted
@@ -94,9 +96,11 @@ def verify_export_general(channel_path, http_submit, http_fetch):
         '<td>51.8</td>' in deferred.result
 
     # NetCDF format.
-    deferred = threads.deferToThread(http_fetch, channel_path, format='nc', ts_from=ts_from, ts_to=ts_to)
-    yield deferred
-    assert deferred.result.startswith(b'\x89HDF\r\n\x1a\n\x02\x08\x08\x00\x00\x00')
+    # netcdf4 fails to build on Python 3.7 with uv (missing hdf5 in pkg-config).
+    if sys.version_info >= (3, 8):
+        deferred = threads.deferToThread(http_fetch, channel_path, format='nc', ts_from=ts_from, ts_to=ts_to)
+        yield deferred
+        assert deferred.result.startswith(b'\x89HDF\r\n\x1a\n\x02\x08\x08\x00\x00\x00')
 
     # Datatables HTML.
     deferred = threads.deferToThread(http_fetch, channel_path, format='dt', ts_from=ts_from, ts_to=ts_to)


### PR DESCRIPTION
## About

Just maintenance: Switch CI to use uv package manager for faster dependency installation and add poe task runner for standardized testing commands.
